### PR TITLE
Align sidebar profile menu across studio pages

### DIFF
--- a/podcast-studio/src/app/video-studio/page.tsx
+++ b/podcast-studio/src/app/video-studio/page.tsx
@@ -1,82 +1,37 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  DropdownMenuSeparator,
-  DropdownMenuLabel,
-} from "@/components/ui/dropdown-menu";
 import { Sidebar } from "@/components/layout/sidebar";
-// Removed Header to avoid a second page-level nav on this route
+import { Header } from "@/components/layout/header";
 import { useSidebar } from "@/contexts/sidebar-context";
 import {
   Video,
-  Settings,
   Play,
   Pause,
   Square,
   FileText,
   Camera,
-  Image,
-  SkipBack,
-  SkipForward,
+  Image as ImageIcon,
   Volume2,
-  Scissors,
   Plus,
   ZoomIn,
   ZoomOut,
   VolumeX,
   Magnet,
-  Menu,
-  MoreHorizontal,
   Folder,
   Sliders,
   Search,
-  Layers,
   Wand2,
-  Palette,
-  Filter,
+  Sparkles,
   Download,
   Upload,
-  Copy,
-  Trash2,
-  RotateCcw,
-  RotateCw,
-  FlipHorizontal,
-  FlipVertical,
-  Crop,
-  Move,
-  MousePointer2,
-  Hand,
   Type,
-  Music,
-  Mic,
-  Headphones,
-  Eye,
-  EyeOff,
-  Lock,
-  Unlock,
-  Star,
-  Sparkles,
-  Zap,
-  Target,
-  Grid,
-  Maximize2,
-  Minimize2,
-  FullScreen,
-  PictureInPicture,
   Rewind,
   FastForward,
-  SkipBackward,
-  SkipForward as SkipForwardIcon,
 } from "lucide-react";
 
 // Shared util so both the main component and SimpleInspectorPanel can render icons
@@ -88,7 +43,7 @@ function getClipTypeIcon(type: VideoClip["type"], size = "w-4 h-4") {
     case "audio":
       return <Volume2 className={`${iconClass} text-green-600`} />;
     case "image":
-      return <Image className={`${iconClass} text-purple-600`} />;
+      return <ImageIcon className={`${iconClass} text-purple-600`} />;
     case "text":
       return <Type className={`${iconClass} text-orange-600`} />;
     case "effect":
@@ -139,43 +94,13 @@ interface VideoClip {
   waveform?: number[];
 }
 
-interface TimelineMarker {
-  id: string;
-  time: number;
-  label?: string;
-  color?: string;
-  type?: "marker" | "chapter" | "cut" | "bookmark";
-}
+type MediaFilter = "all" | "video" | "audio" | "image";
 
-interface Effect {
-  id: string;
+interface MediaAsset {
   name: string;
-  category: "color" | "blur" | "distort" | "stylize" | "noise" | "light";
-  icon: React.ReactNode;
-  previewUrl?: string;
-  parameters: {
-    name: string;
-    type: "slider" | "color" | "dropdown" | "checkbox";
-    min?: number;
-    max?: number;
-    default: any;
-    options?: string[];
-  }[];
+  type: Exclude<MediaFilter, "all">;
+  duration: string;
 }
-
-interface Transition {
-  id: string;
-  name: string;
-  duration: number;
-  type: "fade" | "slide" | "zoom" | "wipe" | "dissolve" | "push";
-  direction?: "left" | "right" | "up" | "down";
-  easing?: "linear" | "ease-in" | "ease-out" | "ease-in-out";
-  previewUrl?: string;
-}
-
-type Tool = "select" | "razor" | "hand" | "zoom" | "text" | "crop";
-
-type ViewMode = "timeline" | "storyboard" | "multicam" | "color";
 
 export default function VideoStudio() {
   // Core playback and timeline state
@@ -194,7 +119,7 @@ export default function VideoStudio() {
   const timelineRef = useRef<HTMLDivElement>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { } = useSidebar();
+  const { collapsed, toggleCollapsed } = useSidebar();
 
   // Enhanced sample data with professional features
   const [videoClips, setVideoClips] = useState<VideoClip[]>([
@@ -276,19 +201,20 @@ export default function VideoStudio() {
     },
   ]);
 
-  const [viewportWidthPx, setViewportWidthPx] = useState(0);
-
   // Simplified media library
   const [mediaQuery, setMediaQuery] = useState("");
-  const [mediaFilter, setMediaFilter] = useState<"all" | "video" | "audio" | "image">("all");
-  
-  const mediaAssets = React.useMemo(() => ([
-    { name: "Host Avatar", type: "video" as const, duration: "0:45" },
-    { name: "Paper Visual", type: "image" as const, duration: "static" },
-    { name: "Background Music", type: "audio" as const, duration: "2:30" },
-    { name: "Diagram Animation", type: "video" as const, duration: "0:30" },
-    { name: "Logo Intro", type: "video" as const, duration: "0:10" },
-  ]), []);
+  const [mediaFilter, setMediaFilter] = useState<MediaFilter>("all");
+
+  const mediaAssets = React.useMemo<MediaAsset[]>(
+    () => [
+      { name: "Host Avatar", type: "video", duration: "0:45" },
+      { name: "Paper Visual", type: "image", duration: "static" },
+      { name: "Background Music", type: "audio", duration: "2:30" },
+      { name: "Diagram Animation", type: "video", duration: "0:30" },
+      { name: "Logo Intro", type: "video", duration: "0:10" },
+    ],
+    [],
+  );
 
   const filteredMediaAssets = React.useMemo(() => {
     const q = mediaQuery.trim().toLowerCase();
@@ -299,15 +225,18 @@ export default function VideoStudio() {
   }, [mediaAssets, mediaFilter, mediaQuery]);
 
   // Simplified track settings
-  const [trackSettings, setTrackSettings] = useState<Record<number, { 
-    mute: boolean; 
-    volume: number; 
+  const [trackSettings, setTrackSettings] = useState<Record<number, {
+    mute: boolean;
+    volume: number;
     name: string;
   }>>({
     1: { mute: false, volume: 1, name: "Video" },
     2: { mute: false, volume: 1, name: "Audio" },
     3: { mute: false, volume: 0.7, name: "Music" },
   });
+
+  const totalClips = videoClips.length;
+  const activeTrackCount = Object.keys(trackSettings).length;
 
   const currentPaper = {
     title: "Attention Is All You Need",
@@ -358,12 +287,6 @@ export default function VideoStudio() {
       return clip;
     }));
   }, [generateWaveform]);
-
-  const updateViewport = () => {
-    if (scrollerRef.current) {
-      setViewportWidthPx(scrollerRef.current.clientWidth || 0);
-    }
-  };
 
   // Playback simulation
   useEffect(() => {
@@ -439,208 +362,335 @@ export default function VideoStudio() {
   };
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-gray-50">
-      <div className="flex-1 flex overflow-hidden">
-        {/* Sidebar */}
-        <div className="hidden md:flex w-56">
-          <Sidebar />
-        </div>
-        
-        {/* Main Content */}
-        <div className="flex-1 flex flex-col overflow-hidden">
-          {/* Video Preview */}
-          <div className="p-4 bg-white border-b border-gray-200">
-            <div className="max-w-4xl mx-auto aspect-video bg-black rounded-lg relative overflow-hidden">
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="text-white/70 text-center">
-                  <Camera className="w-12 h-12 mx-auto mb-2 opacity-50" />
-                  <p className="text-sm">Video Preview</p>
-                  <p className="text-xs opacity-70">{formatTime(currentTime)} / {formatTime(totalDuration)}</p>
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-purple-50/30">
+      <div className="flex">
+        <Sidebar collapsed={collapsed} onToggleCollapse={toggleCollapsed} />
+        <div className="flex-1 flex flex-col">
+          <Header
+            title="Video Studio"
+            description="Craft cinematic episodes with AI-assisted editing tools"
+            status={{
+              label: isPlaying ? "PLAYING" : "PAUSED",
+              color: isPlaying ? "blue" : "gray",
+              active: isPlaying,
+            }}
+            actions={
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={snapEnabled ? "secondary" : "outline"}
+                  onClick={() => setSnapEnabled((previous) => !previous)}
+                  aria-pressed={snapEnabled}
+                  className="hidden sm:inline-flex"
+                >
+                  <Magnet className="h-4 w-4" />
+                  {snapEnabled ? "Snapping on" : "Snapping off"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowWaveforms((previous) => !previous)}
+                >
+                  {showWaveforms ? "Hide waveforms" : "Show waveforms"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="gradient"
+                  onClick={handleAddClipClick}
+                >
+                  <Upload className="h-4 w-4" />
+                  Import media
+                </Button>
+              </div>
+            }
+          />
+
+          <main className="p-6 space-y-6">
+            <div className="flex flex-col gap-6 xl:flex-row">
+              <div className="flex-1 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                <div className="border-b border-gray-200 bg-white p-6">
+                  <div className="relative mx-auto flex aspect-video max-w-4xl items-center justify-center overflow-hidden rounded-xl bg-black">
+                    <div className="text-center text-white/80">
+                      <Camera className="mx-auto mb-3 h-12 w-12 opacity-60" />
+                      <p className="text-sm font-medium">Video Preview</p>
+                      <p className="text-xs text-white/60">
+                        {formatTime(currentTime)} / {formatTime(totalDuration)}
+                      </p>
+                    </div>
+                    <div className="absolute bottom-4 left-4 right-4 flex items-center justify-between gap-2 rounded-lg bg-black/30 p-3 backdrop-blur-sm">
+                      <div className="flex items-center gap-2">
+                        <Button type="button" size="sm" variant="secondary" onClick={() => handleSkip(-10)}>
+                          <Rewind className="h-4 w-4" />
+                        </Button>
+                        <Button type="button" size="sm" variant="secondary" onClick={handlePlayPause}>
+                          {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+                        </Button>
+                        <Button type="button" size="sm" variant="secondary" onClick={() => handleSkip(10)}>
+                          <FastForward className="h-4 w-4" />
+                        </Button>
+                        <Button type="button" size="sm" variant="secondary" onClick={handleStop}>
+                          <Square className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button type="button" size="sm" variant="secondary" onClick={handleZoomOut}>
+                          <ZoomOut className="h-4 w-4" />
+                        </Button>
+                        <Button type="button" size="sm" variant="secondary" onClick={handleZoomIn}>
+                          <ZoomIn className="h-4 w-4" />
+                        </Button>
+                        <Button type="button" size="sm" variant="secondary" onClick={handleAddClipClick}>
+                          <Plus className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="absolute bottom-16 left-4 right-4">
+                      <div className="h-1 rounded-full bg-white/30">
+                        <div
+                          className="h-1 rounded-full bg-purple-500 transition-all"
+                          style={{ width: `${(currentTime / totalDuration) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="border-t border-gray-200">
+                  <div className="flex h-[360px]">
+                    <div className="w-36 flex flex-col border-r border-gray-200 bg-gray-50">
+                      <div className="flex h-12 items-center border-b border-gray-200 px-4">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                          Tracks
+                        </span>
+                      </div>
+                      {Object.entries(trackSettings).map(([trackNum, settings]) => (
+                        <div
+                          key={trackNum}
+                          className="flex h-20 items-center justify-between border-b border-gray-200 px-4"
+                        >
+                          <div>
+                            <p className="text-xs font-semibold text-gray-700">{settings.name}</p>
+                            <p className="text-[11px] text-gray-500">
+                              Volume {(settings.volume * 100).toFixed(0)}%
+                            </p>
+                          </div>
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant={settings.mute ? "destructive" : "ghost"}
+                            onClick={() => toggleTrackMute(parseInt(trackNum))}
+                          >
+                            {settings.mute ? <VolumeX className="h-3 w-3" /> : <Volume2 className="h-3 w-3" />}
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="flex-1 overflow-x-auto" ref={scrollerRef}>
+                      <div
+                        ref={timelineRef}
+                        className="relative bg-white"
+                        style={{
+                          width: `${totalDuration * pixelsPerSecond}px`,
+                          minWidth: "100%",
+                          height: "100%",
+                        }}
+                      >
+                        <div className="relative h-12 border-b border-gray-200 bg-gray-50">
+                          {Array.from({ length: Math.ceil(totalDuration / 10) + 1 }, (_, i) => i * 10).map((time) => (
+                            <div key={time}>
+                              <div
+                                className="absolute inset-y-0 border-l border-gray-300"
+                                style={{ left: `${time * pixelsPerSecond}px` }}
+                              />
+                              <div
+                                className="absolute ml-1 text-xs text-gray-600"
+                                style={{ left: `${time * pixelsPerSecond}px`, top: 4 }}
+                              >
+                                {formatTime(time)}
+                              </div>
+                            </div>
+                          ))}
+                          <div className="absolute right-4 top-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide">
+                            <Magnet className={`h-3 w-3 ${snapEnabled ? "text-purple-600" : "text-gray-400"}`} />
+                            {snapEnabled ? "Snapping on" : "Snapping off"}
+                          </div>
+                          <div
+                            className="pointer-events-none absolute top-0 z-20"
+                            style={{ left: `${currentTime * pixelsPerSecond}px` }}
+                          >
+                            <div className="relative -translate-x-1/2">
+                              <div className="h-0 w-0 border-b-[8px] border-l-[6px] border-r-[6px] border-b-purple-500 border-l-transparent border-r-transparent" />
+                              <div className="absolute top-2 left-1/2 h-[200px] w-[2px] -translate-x-1/2 bg-purple-500" />
+                            </div>
+                          </div>
+                        </div>
+                        {Object.keys(trackSettings).map((trackNum) => (
+                          <div key={trackNum} className="relative h-16 border-b border-gray-200">
+                            {videoClips
+                              .filter((clip) => clip.track === parseInt(trackNum))
+                              .map((clip) => (
+                                <div
+                                  key={clip.id}
+                                  className={`absolute mt-2 h-12 cursor-pointer rounded border-2 transition-all ${
+                                    selectedClips.includes(clip.id)
+                                      ? "border-purple-500 bg-purple-100"
+                                      : "border-gray-300 bg-white hover:border-gray-400"
+                                  }`}
+                                  style={{
+                                    left: `${clip.startTime * pixelsPerSecond}px`,
+                                    width: `${clip.duration * pixelsPerSecond}px`,
+                                    minWidth: "60px",
+                                  }}
+                                  onClick={() => handleClipSelect(clip.id)}
+                                >
+                                  <div className="flex h-full items-center p-2">
+                                    <div className="flex items-center space-x-1">
+                                      {getClipTypeIcon(clip.type)}
+                                      <span className="truncate text-xs font-medium">{clip.name}</span>
+                                    </div>
+                                  </div>
+                                  {clip.type === "audio" && clip.waveform && showWaveforms && (
+                                    <div className="absolute bottom-1 left-1 right-1 flex h-2 items-end space-x-px">
+                                      {clip.waveform
+                                        .slice(0, Math.floor(clip.duration * 2))
+                                        .map((amplitude, index) => (
+                                          <div
+                                            key={`${clip.id}-wave-${index}`}
+                                            className="flex-1 bg-purple-400 opacity-60"
+                                            style={{ height: `${amplitude * 100}%`, minHeight: "1px" }}
+                                          />
+                                        ))}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-              {/* Inline essential controls */}
-              <div className="absolute bottom-4 left-4 right-4 flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2">
-                  <Button size="sm" variant="secondary" onClick={() => handleSkip(-10)}>
-                    <Rewind className="w-4 h-4" />
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={handlePlayPause}>
-                    {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={() => handleSkip(10)}>
-                    <FastForward className="w-4 h-4" />
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={handleStop}>
-                    <Square className="w-4 h-4" />
-                  </Button>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button size="sm" variant="secondary" onClick={handleZoomOut}>
-                    <ZoomOut className="w-4 h-4" />
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={handleZoomIn}>
-                    <ZoomIn className="w-4 h-4" />
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={handleAddClipClick}>
-                    <Plus className="w-4 h-4" />
-                  </Button>
-                </div>
-              </div>
-              
-              {/* Simple scrubber */}
-              <div className="absolute bottom-16 left-4 right-4">
-                <div className="bg-white/20 h-1 rounded-full">
-                  <div 
-                    className="bg-purple-500 h-1 rounded-full transition-all"
-                    style={{ width: `${(currentTime / totalDuration) * 100}%` }}
+
+              <div className="w-full xl:w-80">
+                <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                  <SimpleInspectorPanel
+                    activeTab={activeTab}
+                    setActiveTab={setActiveTab}
+                    mediaAssets={filteredMediaAssets}
+                    mediaQuery={mediaQuery}
+                    setMediaQuery={setMediaQuery}
+                    mediaFilter={mediaFilter}
+                    setMediaFilter={setMediaFilter}
+                    selectedClips={selectedClips}
+                    videoClips={videoClips}
+                    volume={volume}
+                    setVolume={setVolume}
                   />
                 </div>
               </div>
             </div>
-          </div>
-          
-          {/* Timeline */}
-          <div className="flex-1 bg-white border-t border-gray-200 flex">
-            {/* Track Labels */}
-            <div className="w-32 bg-gray-50 border-r border-gray-200">
-              <div className="h-8 border-b border-gray-200 flex items-center px-3">
-                <span className="text-xs font-semibold text-gray-600">TRACKS</span>
-              </div>
-              {Object.entries(trackSettings).map(([trackNum, settings]) => (
-                <div key={trackNum} className="h-16 border-b border-gray-200 flex items-center justify-between px-2">
-                  <span className="text-xs text-gray-600">{settings.name}</span>
-                  <Button
-                    size="xs"
-                    variant={settings.mute ? "destructive" : "ghost"}
-                    onClick={() => toggleTrackMute(parseInt(trackNum))}
-                  >
-                    {settings.mute ? <VolumeX className="w-3 h-3" /> : <Volume2 className="w-3 h-3" />}
-                  </Button>
-                </div>
-              ))}
-            </div>
-            
-            {/* Timeline Area */}
-            <div className="flex-1 overflow-x-auto" ref={scrollerRef}>
-              <div
-                ref={timelineRef}
-                className="relative bg-white"
-                style={{
-                  width: `${totalDuration * pixelsPerSecond}px`,
-                  minWidth: "100%",
-                  height: "100%",
-                }}
-              >
-                {/* Time Ruler */}
-                <div className="h-8 border-b border-gray-200 bg-gray-50 relative">
-                  {Array.from({ length: Math.ceil(totalDuration / 10) + 1 }, (_, i) => i * 10).map((time) => (
-                    <div key={time}>
-                      <div
-                        className="absolute border-l border-gray-300"
-                        style={{
-                          left: `${time * pixelsPerSecond}px`,
-                          top: 0,
-                          bottom: 0,
-                        }}
-                      />
-                      <div
-                        className="absolute text-xs text-gray-600 ml-1"
-                        style={{ left: `${time * pixelsPerSecond}px`, top: 2 }}
-                      >
-                        {formatTime(time)}
-                      </div>
-                    </div>
-                  ))}
 
-                  {/* Playhead */}
-                  <div
-                    className="absolute top-0 z-20 pointer-events-none"
-                    style={{ left: `${currentTime * pixelsPerSecond}px` }}
-                  >
-                    <div className="relative -translate-x-1/2">
-                      <div className="w-0 h-0 border-l-[6px] border-r-[6px] border-b-[8px] border-l-transparent border-r-transparent border-b-purple-500" />
-                      <div className="absolute top-2 left-1/2 -translate-x-1/2 w-[2px] bg-purple-500" style={{ height: '200px' }} />
-                    </div>
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+              <Card className="border-gray-200 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base font-semibold text-gray-900">
+                    Source research
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm text-gray-600">
+                  <p className="font-medium text-gray-900">{currentPaper.title}</p>
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
+                    {currentPaper.authors}
+                  </p>
+                  <div className="rounded-lg bg-purple-50/80 px-3 py-2 text-xs text-purple-700">
+                    Audio reference: {currentPaper.audioFile}
                   </div>
-                </div>
+                  <p className="text-xs text-gray-500">
+                    Keep the research summary visible so narration stays aligned with the paper.
+                  </p>
+                </CardContent>
+              </Card>
 
-                {/* Tracks */}
-                {Object.keys(trackSettings).map((trackNum) => (
-                  <div key={trackNum} className="h-16 border-b border-gray-200 relative">
-                    {videoClips
-                      .filter((clip) => clip.track === parseInt(trackNum))
-                      .map((clip) => (
-                        <div
-                          key={clip.id}
-                          className={`absolute h-12 mt-2 rounded border-2 cursor-pointer transition-all ${
-                            selectedClips.includes(clip.id)
-                              ? "border-purple-500 bg-purple-100"
-                              : "border-gray-300 bg-white hover:border-gray-400"
-                          }`}
-                          style={{
-                            left: `${clip.startTime * pixelsPerSecond}px`,
-                            width: `${clip.duration * pixelsPerSecond}px`,
-                            minWidth: "60px",
-                          }}
-                          onClick={() => handleClipSelect(clip.id)}
-                        >
-                          <div className="p-2 h-full flex items-center">
-                            <div className="flex items-center space-x-1">
-                              {getClipTypeIcon(clip.type)}
-                              <span className="text-xs font-medium truncate">
-                                {clip.name}
-                              </span>
-                            </div>
-                          </div>
-                          
-                          {/* Simple waveform for audio */}
-                          {clip.type === "audio" && clip.waveform && showWaveforms && (
-                            <div className="absolute bottom-1 left-1 right-1 h-2 flex items-end space-x-px">
-                              {clip.waveform.slice(0, Math.floor(clip.duration * 2)).map((amplitude, i) => (
-                                <div
-                                  key={i}
-                                  className="bg-purple-400 opacity-60 flex-1"
-                                  style={{ height: `${amplitude * 100}%`, minHeight: '1px' }}
-                                />
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      ))}
+              <Card className="border-gray-200 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base font-semibold text-gray-900">
+                    Timeline overview
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-gray-600">
+                  <div className="flex items-center justify-between">
+                    <span>Duration</span>
+                    <span className="font-medium text-gray-900">{formatTime(totalDuration)}</span>
                   </div>
-                ))}
-              </div>
+                  <div className="flex items-center justify-between">
+                    <span>Clips</span>
+                    <span className="font-medium text-gray-900">{totalClips}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Tracks</span>
+                    <span className="font-medium text-gray-900">{activeTrackCount}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Waveforms</span>
+                    <span className="font-medium text-gray-900">
+                      {showWaveforms ? "Visible" : "Hidden"}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-gray-200 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base font-semibold text-gray-900">
+                    Export checklist
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-gray-600">
+                  <div className="flex items-center justify-between">
+                    <span>Preset</span>
+                    <span className="font-medium text-gray-900">1080p • 30fps</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>File size estimate</span>
+                    <span className="font-medium text-gray-900">1.2 GB</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Enhancements</span>
+                    <span className="font-medium text-gray-900">Noise cleanup</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Delivery</span>
+                    <span className="font-medium text-gray-900">Podcast & social</span>
+                  </div>
+                  <div className="flex items-center gap-2 pt-2">
+                    <Button type="button" size="sm" variant="gradient" className="flex-1">
+                      <Download className="h-4 w-4" />
+                      Render episode
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" className="flex-1">
+                      <Upload className="h-4 w-4" />
+                      Publish draft
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
             </div>
-          </div>
-        </div>
-        
-        {/* Inspector Panel */}
-        <div className="hidden lg:flex w-80 bg-white border-l border-gray-200">
-          <SimpleInspectorPanel
-            activeTab={activeTab}
-            setActiveTab={setActiveTab}
-            mediaAssets={filteredMediaAssets}
-            mediaQuery={mediaQuery}
-            setMediaQuery={setMediaQuery}
-            mediaFilter={mediaFilter}
-            setMediaFilter={setMediaFilter}
-            selectedClips={selectedClips}
-            videoClips={videoClips}
-            volume={volume}
-            setVolume={setVolume}
-          />
+
+            <input
+              type="file"
+              ref={fileInputRef}
+              accept="video/*,audio/*,image/*"
+              multiple
+              className="hidden"
+              onChange={handleFilesSelected}
+            />
+          </main>
         </div>
       </div>
-      
-      {/* Hidden file input */}
-      <input
-        type="file"
-        ref={fileInputRef}
-        accept="video/*,audio/*,image/*"
-        multiple
-        className="hidden"
-        onChange={handleFilesSelected}
-      />
     </div>
   );
 }
@@ -661,17 +711,18 @@ function SimpleInspectorPanel({
 }: {
   activeTab: string;
   setActiveTab: (tab: string) => void;
-  mediaAssets: any[];
+  mediaAssets: MediaAsset[];
   mediaQuery: string;
   setMediaQuery: (query: string) => void;
-  mediaFilter: "all" | "video" | "audio" | "image";
-  setMediaFilter: (filter: "all" | "video" | "audio" | "image") => void;
+  mediaFilter: MediaFilter;
+  setMediaFilter: (filter: MediaFilter) => void;
   selectedClips: string[];
   videoClips: VideoClip[];
   volume: number;
   setVolume: (volume: number) => void;
 }) {
   const selectedClip = selectedClips.length === 1 ? videoClips.find(c => c.id === selectedClips[0]) : null;
+  const filterOptions: MediaFilter[] = ["all", "video", "audio", "image"];
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
@@ -701,17 +752,17 @@ function SimpleInspectorPanel({
                 />
               </div>
               <div className="flex space-x-1">
-                {["all", "video", "audio", "image"].map((filter) => (
+                {filterOptions.map((filterOption) => (
                   <button
-                    key={filter}
-                    onClick={() => setMediaFilter(filter as any)}
+                    key={filterOption}
+                    onClick={() => setMediaFilter(filterOption)}
                     className={`px-3 py-1 text-xs rounded ${
-                      mediaFilter === filter
+                      mediaFilter === filterOption
                         ? "bg-purple-100 text-purple-700"
                         : "bg-gray-100 text-gray-600 hover:bg-gray-200"
                     }`}
                   >
-                    {filter.charAt(0).toUpperCase() + filter.slice(1)}
+                    {filterOption.charAt(0).toUpperCase() + filterOption.slice(1)}
                   </button>
                 ))}
               </div>
@@ -721,7 +772,7 @@ function SimpleInspectorPanel({
               <div className="p-4 space-y-2">
                 {mediaAssets.map((asset, index) => (
                   <div
-                    key={index}
+                    key={`${asset.type}-${asset.name}-${index}`}
                     className="flex items-center space-x-3 p-3 rounded-lg hover:bg-gray-50 cursor-pointer border border-gray-200"
                   >
                     <div className="w-10 h-10 rounded-lg bg-purple-100 flex items-center justify-center">
@@ -730,7 +781,7 @@ function SimpleInspectorPanel({
                       ) : asset.type === "audio" ? (
                         <Volume2 className="w-5 h-5 text-purple-600" />
                       ) : (
-                        <Image className="w-5 h-5 text-purple-600" />
+                        <ImageIcon className="w-5 h-5 text-purple-600" />
                       )}
                     </div>
                     <div className="flex-1 min-w-0">

--- a/podcast-studio/src/components/layout/sidebar.tsx
+++ b/podcast-studio/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -17,8 +17,22 @@ import {
   ChevronDown,
   Menu,
   X,
+  Mail,
+  MessageCircle,
+  LifeBuoy,
+  ShieldCheck,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 interface SidebarProps {
   children?: React.ReactNode;
@@ -65,6 +79,42 @@ const navigation = [
   },
 ];
 
+type UserMenuKey = "profile" | "settings" | "notifications" | "support";
+
+interface UserMenuItem {
+  key: UserMenuKey;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+const userMenuItems: UserMenuItem[] = [
+  {
+    key: "profile",
+    label: "Profile",
+    description: "Update your name, role, and on-air details.",
+    icon: User,
+  },
+  {
+    key: "settings",
+    label: "Workspace Settings",
+    description: "Control appearance and editing defaults.",
+    icon: Settings,
+  },
+  {
+    key: "notifications",
+    label: "Notifications",
+    description: "Choose when Virtual Podcast Studio alerts you.",
+    icon: Bell,
+  },
+  {
+    key: "support",
+    label: "Support",
+    description: "Reach our team or browse production resources.",
+    icon: HelpCircle,
+  },
+];
+
 export function Sidebar({
   children,
   collapsed = false,
@@ -73,6 +123,455 @@ export function Sidebar({
 }: SidebarProps) {
   const pathname = usePathname();
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const [isUserConfigOpen, setIsUserConfigOpen] = useState(false);
+  const [activeUserMenu, setActiveUserMenu] = useState<UserMenuItem | null>(null);
+  const [profileSettings, setProfileSettings] = useState({
+    fullName: "John Doe",
+    role: "Creator",
+    location: "San Francisco, CA",
+    email: "john.doe@example.com",
+    bio: "Hosts AI-powered conversations and curates research-backed stories.",
+  });
+  const [workspacePreferences, setWorkspacePreferences] = useState({
+    theme: "system" as "system" | "light" | "dark",
+    autoSaveDrafts: true,
+    enableTimelineSnapping: true,
+    showAdvancedAnalytics: false,
+  });
+  const [notificationPreferences, setNotificationPreferences] = useState({
+    emailAlerts: true,
+    productUpdates: true,
+    securityAlerts: true,
+    digestFrequency: "weekly" as "daily" | "weekly" | "monthly",
+  });
+
+  const handleUserMenuItemSelect = useCallback((item: UserMenuItem) => {
+    setActiveUserMenu(item);
+    setShowUserMenu(false);
+    setIsUserConfigOpen(true);
+  }, []);
+
+  const handleUserConfigSheetChange = useCallback((open: boolean) => {
+    setIsUserConfigOpen(open);
+    if (!open) {
+      setActiveUserMenu(null);
+    }
+  }, []);
+
+  const handleUserConfigSave = useCallback(() => {
+    if (!activeUserMenu) {
+      return;
+    }
+
+    switch (activeUserMenu.key) {
+      case "profile":
+        console.info("Profile settings saved", profileSettings);
+        break;
+      case "settings":
+        console.info("Workspace preferences saved", workspacePreferences);
+        break;
+      case "notifications":
+        console.info("Notification preferences saved", notificationPreferences);
+        break;
+      case "support":
+        break;
+      default:
+        break;
+    }
+
+    setIsUserConfigOpen(false);
+    setActiveUserMenu(null);
+  }, [activeUserMenu, notificationPreferences, profileSettings, workspacePreferences]);
+
+  const getPrimaryActionLabel = (key: UserMenuKey) => {
+    switch (key) {
+      case "profile":
+        return "Save profile";
+      case "settings":
+        return "Save workspace";
+      case "notifications":
+        return "Save preferences";
+      case "support":
+        return "Close";
+      default:
+        return "Save";
+    }
+  };
+
+  const renderUserConfiguration = () => {
+    if (!activeUserMenu) {
+      return null;
+    }
+
+    switch (activeUserMenu.key) {
+      case "profile":
+        return (
+          <div className="space-y-5 text-sm text-gray-700">
+            <div>
+              <label
+                htmlFor="profile-full-name"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Display name
+              </label>
+              <input
+                id="profile-full-name"
+                type="text"
+                value={profileSettings.fullName}
+                onChange={(event) =>
+                  setProfileSettings((previous) => ({
+                    ...previous,
+                    fullName: event.target.value,
+                  }))
+                }
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="profile-role"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Role
+              </label>
+              <input
+                id="profile-role"
+                type="text"
+                value={profileSettings.role}
+                onChange={(event) =>
+                  setProfileSettings((previous) => ({
+                    ...previous,
+                    role: event.target.value,
+                  }))
+                }
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="profile-location"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Location
+              </label>
+              <input
+                id="profile-location"
+                type="text"
+                value={profileSettings.location}
+                onChange={(event) =>
+                  setProfileSettings((previous) => ({
+                    ...previous,
+                    location: event.target.value,
+                  }))
+                }
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="profile-email"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Contact email
+              </label>
+              <input
+                id="profile-email"
+                type="email"
+                value={profileSettings.email}
+                onChange={(event) =>
+                  setProfileSettings((previous) => ({
+                    ...previous,
+                    email: event.target.value,
+                  }))
+                }
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="profile-bio"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Bio
+              </label>
+              <textarea
+                id="profile-bio"
+                value={profileSettings.bio}
+                onChange={(event) =>
+                  setProfileSettings((previous) => ({
+                    ...previous,
+                    bio: event.target.value,
+                  }))
+                }
+                rows={3}
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Share a short description that appears on your published show pages.
+              </p>
+            </div>
+          </div>
+        );
+      case "settings":
+        return (
+          <div className="space-y-5 text-sm text-gray-700">
+            <div>
+              <label
+                htmlFor="workspace-theme"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Theme
+              </label>
+              <select
+                id="workspace-theme"
+                value={workspacePreferences.theme}
+                onChange={(event) =>
+                  setWorkspacePreferences((previous) => ({
+                    ...previous,
+                    theme: event.target.value as "system" | "light" | "dark",
+                  }))
+                }
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              >
+                <option value="system">Match system</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </div>
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Editing preferences
+              </p>
+              <label
+                htmlFor="workspace-auto-save"
+                className="flex cursor-pointer items-start space-x-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-purple-200"
+              >
+                <Checkbox
+                  id="workspace-auto-save"
+                  checked={workspacePreferences.autoSaveDrafts}
+                  onCheckedChange={(checked) =>
+                    setWorkspacePreferences((previous) => ({
+                      ...previous,
+                      autoSaveDrafts: checked === true,
+                    }))
+                  }
+                  className="mt-0.5"
+                />
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-gray-900">Auto-save drafts</span>
+                  <p className="text-xs text-gray-500">
+                    Store timeline changes automatically every 30 seconds.
+                  </p>
+                </div>
+              </label>
+              <label
+                htmlFor="workspace-snapping"
+                className="flex cursor-pointer items-start space-x-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-purple-200"
+              >
+                <Checkbox
+                  id="workspace-snapping"
+                  checked={workspacePreferences.enableTimelineSnapping}
+                  onCheckedChange={(checked) =>
+                    setWorkspacePreferences((previous) => ({
+                      ...previous,
+                      enableTimelineSnapping: checked === true,
+                    }))
+                  }
+                  className="mt-0.5"
+                />
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-gray-900">Enable timeline snapping</span>
+                  <p className="text-xs text-gray-500">
+                    Align clips to bars and markers for frame-perfect edits.
+                  </p>
+                </div>
+              </label>
+              <label
+                htmlFor="workspace-analytics"
+                className="flex cursor-pointer items-start space-x-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-purple-200"
+              >
+                <Checkbox
+                  id="workspace-analytics"
+                  checked={workspacePreferences.showAdvancedAnalytics}
+                  onCheckedChange={(checked) =>
+                    setWorkspacePreferences((previous) => ({
+                      ...previous,
+                      showAdvancedAnalytics: checked === true,
+                    }))
+                  }
+                  className="mt-0.5"
+                />
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-gray-900">Show advanced analytics</span>
+                  <p className="text-xs text-gray-500">
+                    Surface engagement metrics alongside every render.
+                  </p>
+                </div>
+              </label>
+            </div>
+          </div>
+        );
+      case "notifications":
+        return (
+          <div className="space-y-5 text-sm text-gray-700">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Delivery channels
+              </p>
+              <label
+                htmlFor="notifications-email"
+                className="flex cursor-pointer items-start space-x-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-purple-200"
+              >
+                <Checkbox
+                  id="notifications-email"
+                  checked={notificationPreferences.emailAlerts}
+                  onCheckedChange={(checked) =>
+                    setNotificationPreferences((previous) => ({
+                      ...previous,
+                      emailAlerts: checked === true,
+                    }))
+                  }
+                  className="mt-0.5"
+                />
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-gray-900">Email alerts</span>
+                  <p className="text-xs text-gray-500">
+                    Get summaries when renders finish or collaborators comment.
+                  </p>
+                </div>
+              </label>
+              <label
+                htmlFor="notifications-updates"
+                className="flex cursor-pointer items-start space-x-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-purple-200"
+              >
+                <Checkbox
+                  id="notifications-updates"
+                  checked={notificationPreferences.productUpdates}
+                  onCheckedChange={(checked) =>
+                    setNotificationPreferences((previous) => ({
+                      ...previous,
+                      productUpdates: checked === true,
+                    }))
+                  }
+                  className="mt-0.5"
+                />
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-gray-900">Product updates</span>
+                  <p className="text-xs text-gray-500">
+                    Learn about new editing features and AI workflows.
+                  </p>
+                </div>
+              </label>
+              <label
+                htmlFor="notifications-security"
+                className="flex cursor-pointer items-start space-x-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-purple-200"
+              >
+                <Checkbox
+                  id="notifications-security"
+                  checked={notificationPreferences.securityAlerts}
+                  onCheckedChange={(checked) =>
+                    setNotificationPreferences((previous) => ({
+                      ...previous,
+                      securityAlerts: checked === true,
+                    }))
+                  }
+                  className="mt-0.5"
+                />
+                <div className="space-y-1">
+                  <span className="flex items-center gap-2 text-sm font-medium text-gray-900">
+                    <ShieldCheck className="h-4 w-4 text-green-500" /> Security alerts
+                  </span>
+                  <p className="text-xs text-gray-500">
+                    Immediate notifications for sign-ins and account changes.
+                  </p>
+                </div>
+              </label>
+            </div>
+            <div>
+              <label
+                htmlFor="notifications-frequency"
+                className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Digest frequency
+              </label>
+              <select
+                id="notifications-frequency"
+                value={notificationPreferences.digestFrequency}
+                onChange={(event) =>
+                  setNotificationPreferences((previous) => ({
+                    ...previous,
+                    digestFrequency: event.target.value as "daily" | "weekly" | "monthly",
+                  }))
+                }
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+              <p className="mt-1 text-xs text-gray-500">
+                Receive a compiled summary of production metrics.
+              </p>
+            </div>
+          </div>
+        );
+      case "support":
+        return (
+          <div className="space-y-4 text-sm text-gray-700">
+            <p className="text-gray-600">
+              Need a hand? The Virtual Podcast Studio team is here to help with
+              production workflows, account questions, and troubleshooting.
+            </p>
+            <div className="space-y-2">
+              <Button
+                variant="outline"
+                className="w-full justify-start"
+                asChild
+              >
+                <a href="mailto:support@virtualpodcast.studio">
+                  <Mail className="mr-2 h-4 w-4 text-purple-600" />
+                  Email support
+                </a>
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full justify-start"
+                asChild
+              >
+                <a
+                  href="https://virtualpodcast.studio/community"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <MessageCircle className="mr-2 h-4 w-4 text-purple-600" />
+                  Join the creator community
+                </a>
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full justify-start"
+                asChild
+              >
+                <a
+                  href="https://virtualpodcast.studio/academy"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <LifeBuoy className="mr-2 h-4 w-4 text-purple-600" />
+                  Browse tutorials & guides
+                </a>
+              </Button>
+            </div>
+            <div className="rounded-xl border border-dashed border-purple-200 bg-purple-50/60 p-4 text-xs text-purple-700">
+              Our support hours are Monday–Friday, 9am–6pm PT. We typically
+              respond within one business day.
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
 
   const getBadgeColor = (badge: string) => {
     if (badge === "LIVE") return "bg-red-500 text-white";
@@ -197,10 +696,13 @@ export function Sidebar({
       <div className={`${collapsed ? "p-2" : "p-4"} border-t border-gray-200/60 flex-shrink-0 relative z-20 bg-white`}>
         <div className="relative">
           <Button
+            type="button"
             variant="ghost"
             title={collapsed ? "John Doe - Creator" : undefined}
+            aria-haspopup="menu"
+            aria-expanded={showUserMenu}
             className={`w-full ${collapsed ? "justify-center" : "justify-start"} text-gray-700 hover:bg-gray-50 hover:text-purple-700 p-2 transition-all duration-200`}
-            onClick={() => setShowUserMenu(!showUserMenu)}
+            onClick={() => setShowUserMenu((previous) => !previous)}
           >
             <div className={`w-8 h-8 bg-gradient-primary rounded-lg flex items-center justify-center ${collapsed ? "mr-0" : "mr-3"} shadow-md`}>
               <User className="w-4 h-4 text-white" />
@@ -220,45 +722,70 @@ export function Sidebar({
 
           {/* User Menu Dropdown */}
           {showUserMenu && !collapsed && (
-            <div className="absolute bottom-full left-4 right-4 mb-2 bg-white border border-gray-200/60 rounded-xl shadow-lg backdrop-blur-sm p-2 space-y-1 z-50">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start hover:bg-gray-50 transition-colors"
-              >
-                <User className="w-4 h-4 mr-2 text-gray-600" />
-                <span className="text-gray-700">Profile</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start hover:bg-gray-50 transition-colors"
-              >
-                <Settings className="w-4 h-4 mr-2 text-gray-600" />
-                <span className="text-gray-700">Settings</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start hover:bg-gray-50 transition-colors"
-              >
-                <Bell className="w-4 h-4 mr-2 text-gray-600" />
-                <span className="text-gray-700">Notifications</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start hover:bg-gray-50 transition-colors"
-              >
-                <HelpCircle className="w-4 h-4 mr-2 text-gray-600" />
-                <span className="text-gray-700">Help</span>
-              </Button>
+            <div className="absolute bottom-full left-4 right-4 mb-2 space-y-1 rounded-xl border border-gray-200/60 bg-white/95 p-2 shadow-lg backdrop-blur-sm z-50">
+              {userMenuItems.map((item) => {
+                const Icon = item.icon;
+                const isActive = activeUserMenu?.key === item.key;
+
+                return (
+                  <Button
+                    key={item.key}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className={`w-full justify-start rounded-lg px-3 py-3 text-left transition-all duration-200 ${
+                      isActive
+                        ? "bg-purple-50 text-purple-700 shadow-inner"
+                        : "text-gray-700 hover:bg-gray-50 hover:text-purple-700"
+                    }`}
+                    onClick={() => handleUserMenuItemSelect(item)}
+                  >
+                    <Icon
+                      className={`mr-3 h-4 w-4 ${
+                        isActive ? "text-purple-600" : "text-gray-500"
+                      }`}
+                    />
+                    <div className="flex-1">
+                      <p className="text-sm font-medium leading-tight">{item.label}</p>
+                      <p className="text-xs text-gray-500">{item.description}</p>
+                    </div>
+                  </Button>
+                );
+              })}
             </div>
           )}
         </div>
       </div>
 
       {children}
+      <Sheet open={isUserConfigOpen} onOpenChange={handleUserConfigSheetChange}>
+        <SheetContent side="right" className="sm:max-w-md p-0">
+          {activeUserMenu ? (
+            <>
+              <SheetHeader className="border-b border-gray-200 px-6 pt-6 pb-4">
+                <SheetTitle>{activeUserMenu.label}</SheetTitle>
+                <SheetDescription>{activeUserMenu.description}</SheetDescription>
+              </SheetHeader>
+              <div
+                className="px-6 py-4"
+                style={{ maxHeight: "calc(100vh - 16rem)", overflowY: "auto" }}
+              >
+                {renderUserConfiguration()}
+              </div>
+              <SheetFooter className="px-6 pb-6">
+                <Button
+                  type="button"
+                  variant={activeUserMenu.key === "support" ? "outline" : "gradient"}
+                  className="w-full"
+                  onClick={handleUserConfigSave}
+                >
+                  {getPrimaryActionLabel(activeUserMenu.key)}
+                </Button>
+              </SheetFooter>
+            </>
+          ) : null}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor the sidebar user profile section to drive dropdown items from configuration and surface actionable settings via a sheet
- standardize the Video Studio layout to share the sidebar/header pattern, add status actions, and surface project summary cards beneath the timeline

## Testing
- npm run lint *(fails: existing realtime API routes rely on `any` and trigger lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a412d828832e8403e7d998741015