### PR TITLE
Refactor API key management for realtime sessions

### DIFF
--- a/podcast-studio/src/app/api/rt/status/route.ts
+++ b/podcast-studio/src/app/api/rt/status/route.ts
@@ -15,7 +15,8 @@ export async function GET(req: Request) {
     const status = manager.getStatus();
     const isActive = manager.isActive();
     const isStarting = manager.isStarting();
-    
+    const config = manager.getConfiguration();
+
     const response = {
       ok: true,
       sessionId,
@@ -23,11 +24,14 @@ export async function GET(req: Request) {
       isActive,
       isStarting,
       activeSessionCount: rtSessionManager.getActiveSessionCount(),
+      provider: config.provider,
+      hasApiKey: config.hasApiKey,
+      model: config.model,
       timestamp: new Date().toISOString()
     };
-    
+
     console.log(`[DEBUG] Status response`, response);
-    
+
     return NextResponse.json(response);
     
   } catch (error: any) {

--- a/podcast-studio/src/app/layout.tsx
+++ b/podcast-studio/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { SidebarProvider } from "@/contexts/sidebar-context";
+import { ApiConfigProvider } from "@/contexts/api-config-context";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -33,9 +34,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.className} antialiased`} suppressHydrationWarning={true}>
-        <SidebarProvider>
-          {children}
-        </SidebarProvider>
+        <ApiConfigProvider>
+          <SidebarProvider>
+            {children}
+          </SidebarProvider>
+        </ApiConfigProvider>
       </body>
     </html>
   );

--- a/podcast-studio/src/contexts/api-config-context.tsx
+++ b/podcast-studio/src/contexts/api-config-context.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export type LlmProvider = "openai" | "google";
+
+interface StoredApiConfig {
+  activeProvider: LlmProvider;
+  apiKeys: Record<LlmProvider, string>;
+  models?: Partial<Record<LlmProvider, string>>;
+}
+
+interface ApiConfigContextValue {
+  activeProvider: LlmProvider;
+  apiKeys: Record<LlmProvider, string>;
+  models: Partial<Record<LlmProvider, string>>;
+  setActiveProvider: (provider: LlmProvider) => void;
+  setApiKey: (provider: LlmProvider, key: string) => void;
+  clearApiKey: (provider: LlmProvider) => void;
+  setModel: (provider: LlmProvider, model: string) => void;
+}
+
+const STORAGE_KEY = "vps:llmConfig";
+
+const defaultState: StoredApiConfig = {
+  activeProvider: "openai",
+  apiKeys: {
+    openai: "",
+    google: "",
+  },
+  models: {},
+};
+
+const ApiConfigContext = createContext<ApiConfigContextValue | undefined>(
+  undefined,
+);
+
+interface ApiConfigProviderProps {
+  children: React.ReactNode;
+}
+
+function normalizeProvider(value: unknown): LlmProvider {
+  return value === "google" ? "google" : "openai";
+}
+
+export function ApiConfigProvider({ children }: ApiConfigProviderProps) {
+  const [state, setState] = useState<StoredApiConfig>(defaultState);
+  const [hasHydrated, setHasHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<StoredApiConfig>;
+        setState({
+          activeProvider: normalizeProvider(parsed.activeProvider),
+          apiKeys: {
+            openai: parsed.apiKeys?.openai ?? "",
+            google: parsed.apiKeys?.google ?? "",
+          },
+          models: parsed.models ?? {},
+        });
+      }
+    } catch (error) {
+      console.error("Failed to hydrate API configuration", error);
+    } finally {
+      setHasHydrated(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydrated) {
+      return;
+    }
+
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.error("Failed to persist API configuration", error);
+    }
+  }, [state, hasHydrated]);
+
+  const setActiveProvider = useCallback((provider: LlmProvider) => {
+    setState((previous) => ({
+      ...previous,
+      activeProvider: provider,
+    }));
+  }, []);
+
+  const setApiKey = useCallback((provider: LlmProvider, key: string) => {
+    setState((previous) => ({
+      ...previous,
+      apiKeys: {
+        ...previous.apiKeys,
+        [provider]: key,
+      },
+    }));
+  }, []);
+
+  const clearApiKey = useCallback((provider: LlmProvider) => {
+    setApiKey(provider, "");
+  }, [setApiKey]);
+
+  const setModel = useCallback((provider: LlmProvider, model: string) => {
+    setState((previous) => ({
+      ...previous,
+      models: {
+        ...previous.models,
+        [provider]: model,
+      },
+    }));
+  }, []);
+
+  const value = useMemo<ApiConfigContextValue>(() => ({
+    activeProvider: state.activeProvider,
+    apiKeys: state.apiKeys,
+    models: state.models ?? {},
+    setActiveProvider,
+    setApiKey,
+    clearApiKey,
+    setModel,
+  }), [state, setActiveProvider, setApiKey, clearApiKey, setModel]);
+
+  return (
+    <ApiConfigContext.Provider value={value}>
+      {children}
+    </ApiConfigContext.Provider>
+  );
+}
+
+export function useApiConfig() {
+  const context = useContext(ApiConfigContext);
+  if (context === undefined) {
+    throw new Error("useApiConfig must be used within an ApiConfigProvider");
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add an ApiConfigProvider to store OpenAI and Google API keys/client preferences in local storage
- extend the sidebar settings sheet with provider selection plus form inputs for OpenAI and Google keys
- wire the studio page and realtime API routes to use the active provider/key, rejecting unsupported Google realtime sessions for now and surfacing clearer errors
- refactor the realtime session manager to accept dynamic provider configuration and report its status

## Testing
- npm run lint *(fails: legacy lint violations that predated this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac2d0854832e9cd9fc302da46334