### PR TITLE
Improve AGENT documentation for backend and frontend

### DIFF
--- a/podcast-studio/src/app/api/rt/AGENT.md
+++ b/podcast-studio/src/app/api/rt/AGENT.md
@@ -1,0 +1,69 @@
+# Realtime API Routes – Agent Guide
+
+All files in this folder proxy browser requests to the server-side `rtSessionManager`
+(`src/lib/realtimeSession.ts`). They run on the Node.js runtime and must remain server-only
+(avoid importing client modules).
+
+```
+src/app/api/rt/
+├── start/route.ts          # Bootstrap or reconfigure a session
+├── status/route.ts         # Inspect session state
+├── stop/route.ts           # Tear down a session
+├── webrtc/route.ts         # SDP exchange with OpenAI
+├── audio-append/route.ts   # Upload PCM16 chunks
+├── audio-commit/route.ts   # Signal end-of-turn for audio
+├── text/route.ts           # Send typed messages
+├── audio/route.ts          # SSE stream of assistant audio (base64 PCM16)
+├── transcripts/route.ts    # SSE stream of assistant text deltas
+├── user-transcripts/route.ts # SSE stream of user speech transcripts
+└── AGENT.md                # This guide
+```
+
+## Lifecycle Overview
+1. **`POST /api/rt/start`** – Configures a session with `{sessionId, provider, apiKey, model}`.
+   Uses `rtSessionManager.getSession(sessionId)` and calls `configure()` + `start()`. Returns
+   `{ok, status, provider}` or surfaces meaningful error messages (missing API key,
+   authentication failure, timeout, etc.).
+2. **`POST /api/rt/webrtc`** – Accepts a browser SDP offer, forwards it to OpenAI (`/v1/realtime`)
+   with the resolved API key/model, and returns the SDP answer. Only the `openai` provider is
+   supported (others return 501).
+3. **Realtime traffic** – After `start()` succeeds:
+   - Upload microphone data via `/api/rt/audio-append` (base64 PCM16) followed by
+     `/api/rt/audio-commit` once a batch is flushed.
+   - Send typed chat via `/api/rt/text`.
+   - Subscribe to SSE endpoints for assistant audio (`/audio`), assistant text (`/transcripts`),
+     and user speech transcripts (`/user-transcripts`). Each handler listens to corresponding
+     `EventEmitter` events and cleans up listeners when the stream closes.
+4. **`POST /api/rt/stop`** – Removes the session from the manager, closing sockets and clearing
+   auto-cleanup timers.
+5. **`GET /api/rt/status`** – Diagnostic endpoint returning `{status, isActive, isStarting,
+   provider, model, activeSessionCount}` to help verify the manager state.
+
+## Implementation Notes
+- Every route sets `export const runtime = "nodejs";` (either explicitly or implicitly). Do not
+  import `next/headers`/`cookies` since they are not available in the Node runtime when using
+  streaming responses.
+- SSE routes (`audio`, `transcripts`, `user-transcripts`) construct a `ReadableStream`. Attach
+  `manager.on(...)` listeners inside `start()` and store cleanup functions on the controller so
+  `cancel()` removes listeners and clears intervals. Always send an initial message so clients
+  know the stream is alive.
+- Error handling: catch exceptions from manager methods and return structured JSON with `{error,
+  sessionId}` where helpful. Honor HTTP status codes (e.g., 503 when the session is not active).
+- Keep logging informative but not noisy; the session manager already writes detailed logs.
+
+## Extending the API
+- When adding new realtime capabilities (e.g., file uploads, conversation commands), extend
+  `realtimeSession.ts` first, then mirror the behaviour in a new route under this directory.
+- Document any new EventEmitter names in both this file and the session manager AGENT so client
+  consumers know what to expect.
+- Maintain the session ID convention: the Audio Studio uses `session_${Date.now()}` and passes it
+  on every request; new routes should accept the same parameter to keep multiplexing working.
+
+## Testing
+- With the dev server running, issue:
+  - `POST /api/rt/start` (supply `sessionId` and API key in the body).
+  - `GET /api/rt/status?sessionId=...` to verify `status === 'active'`.
+  - Stream from `/api/rt/audio?sessionId=...` using `curl` or browser DevTools and confirm base64
+    frames arrive.
+  - Send text via `POST /api/rt/text` and watch `/api/rt/transcripts` for deltas.
+  - Call `/api/rt/stop` and ensure SSE streams close promptly.

--- a/podcast-studio/src/components/layout/AGENT.md
+++ b/podcast-studio/src/components/layout/AGENT.md
@@ -1,0 +1,59 @@
+# Layout Components – Agent Guide
+
+The files in this directory compose the global chrome for every page: sidebar navigation,
+header, and workspace/user menus. They are client components that assume the `SidebarProvider`
+and `ApiConfigProvider` contexts are available (via `src/app/layout.tsx`).
+
+```
+src/components/layout/
+├── sidebar.tsx   # Navigation + collapse controls
+├── header.tsx    # Page title, status badges, search, actions
+├── user-menu.tsx # Avatar dropdown + workspace settings sheet
+└── AGENT.md      # This guide
+```
+
+## Sidebar (`sidebar.tsx`)
+- Reads `useSidebar()` to toggle the collapsed state and highlights the active route via
+  `usePathname()`.
+- Accepts `isLiveRecording` to control the "LIVE" badge for the Audio Studio. Pass this prop
+  from pages that manage realtime sessions to keep UX consistent.
+- Navigation items are hard-coded (Research Hub, Audio Studio, Video Studio, Publisher, Library).
+  When modifying, update both the icon and descriptive copy. Keep badges short; they render in a
+  pill with Tailwind classes derived from `getBadgeColor`.
+
+## Header (`header.tsx`)
+- Displays the page title/description plus optional `status`, `timer`, `progress`, `actions`, and
+  `search` props.
+- `status` expects `{label, color, active}`. Colors map to Tailwind classes in helper functions;
+  add new colors there if needed.
+- `search.onSearch` currently just logs input. If you wire it up, debounce in the page component
+  so the header stays stateless.
+- Always render `<UserMenu />` as the last item so workspace settings are accessible on every
+  page.
+
+## User Menu (`user-menu.tsx`)
+- Combines Radix `DropdownMenu` and `Sheet` primitives to show profile settings and workspace
+  configuration.
+- Uses `useApiConfig()` to read/write API provider selections and keys. Persisted values are
+  trimmed before saving back to context/localStorage.
+- Profile/workspace UI uses local component state with optimistic logging (`console.info`). If
+  you integrate a backend, replace the logs with API calls but keep the separation between profile
+  and workspace sections.
+- The workspace sheet exposes checkboxes for preferences and forms for API keys. Maintain the
+  base field class (`baseFieldClass`) for consistent styling when adding new inputs.
+
+## Implementation Tips
+- All components assume they are rendered as part of a responsive flex layout (see
+  `src/app/page.tsx`). When adding new sections, ensure collapsed sidebar width (`w-16`) still
+  accommodates icons without overflowing.
+- Use icons from `lucide-react` and keep them sized with Tailwind `w-4 h-4`/`w-5 h-5` utilities
+  to align with current spacing.
+- Prefer `Button` variants defined in `src/components/ui/button.tsx` when adding actions—this
+  keeps gradient/glass styling consistent.
+
+## Testing
+- Toggle the sidebar collapse/expand button at multiple viewport widths.
+- Open the user menu, switch providers/keys, close the sheet, and reload the page to ensure
+  settings persist and UI state resets.
+- Validate keyboard navigation: tab through header controls, open the dropdown with Enter/Space,
+  and ensure focus returns to the trigger on close.

--- a/podcast-studio/src/components/ui/AGENT.md
+++ b/podcast-studio/src/components/ui/AGENT.md
@@ -1,179 +1,73 @@
 # UI Components Agent Guide
 
-## 🎯 Purpose
+## Purpose
+Reusable UI primitives built on top of shadcn/ui (Radix UI + Tailwind) live in this folder.
+They provide consistent theming for the Research Hub, Studio, and post-production pages.
+Each component exports semantic props and uses the shared `cn` helper from
+`src/lib/utils.ts`.
 
-Reusable UI components built with Shadcn/UI and Radix UI primitives for the Virtual Podcast Studio application. These components support the complete podcast production pipeline from Research Hub to Audio Studio, Video Studio, and Publisher phases.
-
-## 📁 File Structure
-
-```text
+```
 src/components/ui/
-├── button.tsx           # Button component
-├── card.tsx             # Card component
-├── checkbox.tsx         # Checkbox component
-├── scroll-area.tsx      # Scrollable area component
-└── AGENT.md             # This file
+├── button.tsx        # cva-powered gradient buttons
+├── card.tsx          # Glass/gradient cards with header/content slots
+├── checkbox.tsx      # Radix checkbox, Tailwind focus styles
+├── dropdown-menu.tsx # Workspace menu, keyboard friendly
+├── scroll-area.tsx   # Styled viewport + scrollbar
+├── sheet.tsx         # Settings drawer (Radix dialog)
+├── tabs.tsx          # Timeline/analytics tab strip
+└── AGENT.md          # This guide
 ```
 
-## 🎨 Component Overview
+## Component Notes
+- **Button** (`button.tsx`)
+  - Uses `class-variance-authority` to expose `variant` (`default`, `gradient`, `glass`,
+    `outline`, etc.) and `size` props. Extend variants here before referencing them in pages.
+  - `asChild` lets you wrap anchors (`<Button asChild><a/></Button>`), preserving focus
+    styles.
+- **Card** (`card.tsx`)
+  - Layout-friendly slots (`CardHeader`, `CardContent`, `CardFooter`, etc.) with subtle
+    borders and backdrop blur. Keep padding consistent—Research Hub and Studio rely on the
+    default spacing.
+- **Checkbox** (`checkbox.tsx`)
+  - Wraps `@radix-ui/react-checkbox` with Tailwind focus rings. Only accepts boolean `checked`
+    and `onCheckedChange` from Radix. Keep icons sized with `size-3.5` to align with topic
+    toggles.
+- **DropdownMenu** (`dropdown-menu.tsx`)
+  - Provides menu items, separators, shortcuts, checkbox/radio items, and submenus. Each item
+    forwards the `data-variant` attribute (default/destructive). Update this file if you need
+    new menu surface styles rather than inlining overrides.
+- **ScrollArea** (`scroll-area.tsx`)
+  - Combines `ScrollArea.Root`, `.Viewport`, and `.Scrollbar` with custom thumb styling.
+    Reuse for scrollable panels instead of raw `<div>` overflow to keep consistent
+    scrollbar/keep-alive behaviour.
+- **Sheet** (`sheet.tsx`)
+  - Radix dialog configured as a sliding drawer (right/left/top/bottom). The Settings sheet
+    depends on the `side="right"` animation classes—keep transitions intact when editing.
+- **Tabs** (`tabs.tsx`)
+  - Inline-flex tab list with active-state border and focus rings. Used heavily by the Video
+    Studio; maintain the root/list/trigger/content structure so keyboard navigation works.
 
-### Button (`button.tsx`)
+## Styling Conventions
+- All components rely on the design tokens defined in `globals.css` (`gradient-primary`,
+  `glass`, `shadow-*`). If you introduce a new visual treatment, add utility classes there
+  rather than hard-coding hex values.
+- Focus states come from Tailwind (`focus-visible:ring-[3px]` etc.). Keep them accessible and
+  ensure `data-slot` attributes remain so design tooling can target them.
+- When adding new components, prefer `@radix-ui` primitives to maintain accessibility. Follow
+  the patterns above: wrap the primitive, apply Tailwind classes, and export named helpers.
 
-- **Purpose**: Primary and secondary action buttons
-- **Variants**: Default, outline, ghost, link
-- **Sizes**: Default, sm, lg, icon
-- **Usage**: Fetch Papers, Clear Selection buttons
+## Usage Tips
+- Import components via aliases (`@/components/ui/button`). The Next.js `tsconfig` path
+  handles alias resolution.
+- Compose shadcn components using the exported slots: e.g., `Card` + `CardHeader` +
+  `CardContent`. Avoid creating ad-hoc wrappers in page files; extend the primitive if the
+  pattern is shared.
+- Keep props typed – extend `React.ComponentProps<typeof Primitive>` when adding options so
+  TypeScript infers the correct attributes.
 
-### Card (`card.tsx`)
-
-- **Purpose**: Container for paper information
-- **Components**: Card, CardHeader, CardContent, CardFooter
-- **Usage**: Paper display cards with hover effects
-
-### Checkbox (`checkbox.tsx`)
-
-- **Purpose**: Topic selection checkboxes
-- **Features**: Controlled state, accessibility
-- **Usage**: Topic selection grid
-
-### ScrollArea (`scroll-area.tsx`)
-
-- **Purpose**: Scrollable container for paper list
-- **Features**: Custom scrollbar, smooth scrolling
-- **Usage**: Paper preview section
-
-## 🎨 Styling System
-
-### Design Tokens
-
-- **Colors**: Gray palette (900, 800, 700, 600, 500, 400, 300)
-- **Spacing**: Tailwind spacing scale
-- **Typography**: Inter font family
-- **Shadows**: Subtle shadows for depth
-
-### Component Variants
-
-- **Primary**: Blue buttons (`bg-blue-600`)
-- **Secondary**: Gray outline buttons (`border-gray-500`)
-- **Cards**: Dark cards (`bg-gray-700`) with hover (`hover:bg-gray-600`)
-
-## 🔧 Usage Examples
-
-### Button Usage
-
-```tsx
-// Primary button
-<Button className="bg-blue-600 hover:bg-blue-700">
-  Fetch Papers
-</Button>
-
-// Outline button
-<Button variant="outline" className="border-gray-500">
-  Clear Selection
-</Button>
-```
-
-### Card Usage
-
-```tsx
-<Card className="bg-gray-700 border-gray-600 hover:bg-gray-600">
-  <CardContent>
-    <h3>{paper.title}</h3>
-    <p>{paper.authors}</p>
-  </CardContent>
-</Card>
-```
-
-### Checkbox Usage
-
-```tsx
-<Checkbox
-  id={topic.id}
-  checked={selectedTopics.includes(topic.id)}
-  onCheckedChange={() => handleTopicToggle(topic.id)}
-/>
-```
-
-## 🛠️ Development Notes
-
-### Shadcn/UI Integration
-
-- **Installation**: `npx shadcn-ui@latest add [component]`
-- **Customization**: Modify component files directly
-- **Styling**: Use Tailwind CSS classes
-- **Accessibility**: Built-in ARIA attributes
-
-### Component Patterns
-
-- **Composition**: Use compound components (Card + CardContent)
-- **Variants**: Use variant prop for different styles
-- **Forwarding**: Forward refs for proper DOM access
-- **TypeScript**: Full type safety with proper interfaces
-
-## 🐛 Common Issues
-
-### Styling Conflicts
-
-- **Problem**: Tailwind classes not applying
-- **Solution**: Check CSS import order
-- **Debug**: Use browser dev tools
-
-### Accessibility Issues
-
-- **Problem**: Missing ARIA attributes
-- **Solution**: Use Radix UI primitives
-- **Test**: Use screen reader testing
-
-### TypeScript Errors
-
-- **Problem**: Type mismatches
-- **Solution**: Check component prop types
-- **Debug**: Use TypeScript compiler
-
-## 🔍 Testing
-
-### Component Testing
-
-- **Visual**: Test in browser
-- **Accessibility**: Use screen reader
-- **Responsive**: Test on different screen sizes
-- **Interaction**: Test hover/focus states
-
-### Integration Testing
-
-- **State**: Test with React state
-- **Props**: Test different prop combinations
-- **Events**: Test click handlers
-
-## 📝 When Modifying
-
-### Adding New Components
-
-1. Use `npx shadcn-ui@latest add [component]`
-2. Customize styling as needed
-3. Test accessibility
-4. Document usage
-
-### Modifying Existing Components
-
-1. Update component file
-2. Test all usage locations
-3. Ensure backward compatibility
-4. Update documentation
-
-### Styling Changes
-
-1. Modify Tailwind classes
-2. Test responsive design
-3. Ensure contrast ratios
-4. Test dark theme
-
-## 🎯 Agent Instructions
-
-- Always test components in isolation
-- Maintain accessibility standards
-- Use consistent styling patterns
-- Follow Shadcn/UI conventions
-- Test responsive behavior
-- Document component APIs
-- Ensure TypeScript compliance
+## Testing
+- Visual regressions: run the Next.js dev server (`npm run dev`) and inspect focus/hover
+  states in dark/light modes.
+- Accessibility: validate keyboard navigation for DropdownMenu, Sheet, and Tabs when altering
+  markup. Radix handles most ARIA attributes; avoid removing structural wrappers that provide
+  them.

--- a/podcast-studio/src/contexts/AGENT.md
+++ b/podcast-studio/src/contexts/AGENT.md
@@ -1,0 +1,49 @@
+# Context Providers – Agent Guide
+
+Two React contexts live in this directory. Both are client components and are composed in
+`src/app/layout.tsx` so every page shares the same state.
+
+```
+src/contexts/
+├── sidebar-context.tsx   # Collapse state for layout chrome
+├── api-config-context.tsx # Persisted API provider + keys
+└── AGENT.md               # This guide
+```
+
+## Sidebar Context
+- `SidebarProvider` stores a simple boolean `collapsed` state with `toggleCollapsed` and
+  `setCollapsed` helpers.
+- Any component calling `useSidebar()` must be rendered within the provider. The layout wrapper
+  already does this, but unit tests or Storybook entries should wrap components explicitly.
+- When adding new sidebar UI affordances (e.g., multi-column layouts), extend the context shape
+  cautiously. Keep backwards compatibility in mind because many components destructure
+  `collapsed` and `toggleCollapsed` directly.
+
+## API Config Context
+- `ApiConfigProvider` persists the user's chosen LLM provider (`openai` or `google`), API keys,
+  and optional model overrides to `localStorage` under `vps:llmConfig`.
+- Hydration flow:
+  1. On mount, attempt to read and parse the stored JSON.
+  2. `hasHydrated` guards against writing back until the initial read completes.
+  3. Any state mutation (provider, key, model) re-serializes to `localStorage`.
+- Consumers (`useApiConfig`) receive `{ activeProvider, apiKeys, models, setActiveProvider,
+  setApiKey, clearApiKey, setModel }`.
+- The Audio Studio relies on this context to gate `/api/rt/start` calls. Maintain the guard that
+  falls back to the environment `OPENAI_API_KEY` only on the server—client components should
+  always respect the user-specified keys.
+
+## Implementation Tips
+- Keep both providers client components (they access browser storage). Mark new providers with
+  `"use client"` and wrap them in `layout.tsx` so Server Components can still render children.
+- When extending the stored data shape, bump `defaultState` with sensible defaults and ensure
+  migration logic handles older payloads gracefully (e.g., optional chaining when reading
+  `parsed.apiKeys`).
+- Avoid writing to `localStorage` during SSR. The current guard (`hasHydrated`) prevents this;
+  preserve that pattern if you refactor.
+
+## Testing
+- Manual: open the Settings sheet, swap providers, add/remove API keys, refresh the page, and
+  confirm the selections persist.
+- Automated: consider writing React Testing Library tests that render consumers under the
+  provider and exercise `setApiKey`/`clearApiKey` to ensure serialization does not throw in
+  `jsdom`.

--- a/podcast-studio/src/lib/AGENT.md
+++ b/podcast-studio/src/lib/AGENT.md
@@ -1,0 +1,52 @@
+# Library Modules – Agent Guide
+
+The `src/lib` directory contains utilities used by API routes and client components. The
+realtime session manager is the heart of the server-side realtime workflow; treat it with
+care.
+
+```
+src/lib/
+├── realtimeSession.ts # Node-side singleton talking to OpenAI Realtime
+├── utils.ts           # Tailwind-friendly `cn()` helper
+└── AGENT.md           # This guide
+```
+
+## `realtimeSession.ts`
+- Exports a hot-reload-safe singleton (`rtSessionManager`) that stores `RTManager` instances by
+  `sessionId`. Each `RTManager` maintains a WebSocket connection to OpenAI and exposes helper
+  methods used by API routes (`start`, `appendPcm16`, `commitTurn`, `sendText`, `stop`).
+- Connection flow:
+  1. `start()` verifies an API key, fetches `/v1/models` as a sanity check, and opens the
+     realtime WebSocket.
+  2. `_setupWebSocketHandlers` sends a `session.update` payload configuring modalities, voice,
+     transcription, and server-side VAD. Modify this payload carefully—the Audio Studio assumes
+     text+audio modes are enabled.
+  3. Incoming events emit on the `EventEmitter` interface: `audio`, `transcript`,
+     `user_transcript`, `user_transcript_delta`, `assistant_done`, `close`, and `error`.
+     API routes under `src/app/api/rt` stream these events back to the browser via SSE.
+  4. `responseInFlight` prevents duplicate `response.create` calls. When you add new event types,
+     update `_handleEvent` to keep this guard accurate.
+- Session cleanup: `RTSessionManager.removeSession` calls `stop()` and clears timeouts. Idle
+  sessions auto-expire after 30 minutes. Always go through the manager (never instantiate
+  `RTManager` directly) so cleanup runs reliably.
+- Provider support: only `openai` is implemented. The Google branch throws a descriptive error.
+  If you implement another provider, update `configure`, `_establishConnection`, and the API
+  routes to accept provider-specific headers.
+
+## `utils.ts`
+- Simple `cn()` helper that merges class names using `clsx` + `tailwind-merge`. Use it everywhere
+  you compose Tailwind classes to avoid conflicting utilities.
+
+## Implementation Guidelines
+- Keep `realtimeSession.ts` Node-compatible. App Router API routes import it with
+  `export const runtime = "nodejs";`. Avoid referencing browser APIs inside the module.
+- When adding new events to the emitter, document them in the `src/app/api/rt/AGENT.md` (see
+  below) and update any SSE consumers in the Audio Studio.
+- Logging uses `log.info/error/warn/debug`; keep logs concise and avoid printing raw audio buffers
+  or secrets.
+
+## Testing
+- Start the Next.js dev server and hit `/api/rt/start`, `/api/rt/status`, `/api/rt/audio` etc.
+  while watching server logs to ensure events trigger as expected.
+- Use a standalone Node script to instantiate `rtSessionManager.getSession('test')` and exercise
+  `start()`/`sendText()` when experimenting with new provider settings.


### PR DESCRIPTION
## Summary
- rewrite the backend AGENT to document rate limiting, paper ingestion, and realtime websocket relaying
- refresh the frontend root AGENT and UI/Research/Studio guides to outline data flow, contexts, realtime APIs, and styling conventions
- add focused AGENTs for the realtime API routes, layout components, shared contexts, and realtime session manager so contributors can navigate those directories

## Testing
- npm run lint *(fails: existing eslint complaints in realtime API/server utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e9060168832ea2de5c408d3d0a80