### PR TITLE
Create dedicated analytics dashboard and clean up existing pages

### DIFF
--- a/podcast-studio/src/app/analytics/page.tsx
+++ b/podcast-studio/src/app/analytics/page.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import { useMemo } from "react";
+import { Sidebar } from "@/components/layout/sidebar";
+import { Header } from "@/components/layout/header";
+import { useSidebar } from "@/contexts/sidebar-context";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  BookOpen,
+  Brain,
+  Clock,
+  LineChart,
+  Mic,
+  Sparkles,
+  TrendingUp,
+  Users,
+  BarChart3,
+  ArrowUpRight,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { defaultSeasons, type Episode, type Season } from "@/data/library";
+
+type OverviewCard = {
+  label: string;
+  value: string;
+  change: string;
+  icon: LucideIcon;
+  iconBg: string;
+  iconColor: string;
+};
+
+type TopicMomentum = {
+  topic: string;
+  sentiment: string;
+  progress: number;
+  delta: string;
+};
+
+type EpisodeHighlight = {
+  id: string;
+  title: string;
+  views: number;
+  seasonTitle: string;
+};
+
+const overviewCards: OverviewCard[] = [
+  {
+    label: "Papers Analyzed",
+    value: "1,247",
+    change: "+12% vs last week",
+    icon: BookOpen,
+    iconBg: "bg-purple-100",
+    iconColor: "text-purple-600",
+  },
+  {
+    label: "Episodes Created",
+    value: "89",
+    change: "+6 new this month",
+    icon: Mic,
+    iconBg: "bg-blue-100",
+    iconColor: "text-blue-600",
+  },
+  {
+    label: "Audience Reach",
+    value: "45.2K",
+    change: "+3.1% vs last season",
+    icon: Users,
+    iconBg: "bg-emerald-100",
+    iconColor: "text-emerald-600",
+  },
+  {
+    label: "Research Hours Saved",
+    value: "156",
+    change: "Automations saved 42 hrs",
+    icon: Clock,
+    iconBg: "bg-amber-100",
+    iconColor: "text-amber-600",
+  },
+];
+
+const topicMomentum: TopicMomentum[] = [
+  {
+    topic: "Artificial Intelligence",
+    sentiment: "High engagement",
+    progress: 86,
+    delta: "+8.2%",
+  },
+  {
+    topic: "Machine Learning",
+    sentiment: "Consistent growth",
+    progress: 78,
+    delta: "+5.4%",
+  },
+  {
+    topic: "Computer Vision",
+    sentiment: "Emerging interest",
+    progress: 64,
+    delta: "+3.7%",
+  },
+  {
+    topic: "Robotics",
+    sentiment: "Steady research",
+    progress: 58,
+    delta: "+2.1%",
+  },
+];
+
+const engagementTimeline = [
+  { week: "Week 1", audience: "10.2K", change: "+4.3%" },
+  { week: "Week 2", audience: "11.8K", change: "+6.1%" },
+  { week: "Week 3", audience: "12.5K", change: "+3.4%" },
+  { week: "Week 4", audience: "13.7K", change: "+5.6%" },
+];
+
+export default function AnalyticsPage() {
+  const { collapsed, toggleCollapsed } = useSidebar();
+  const seasons: Season[] = defaultSeasons;
+
+  const {
+    totalEpisodes,
+    publishedEpisodes,
+    processingEpisodes,
+    draftEpisodes,
+    totalViews,
+    averageViews,
+    topEpisodes,
+  } = useMemo(() => {
+    let published = 0;
+    let processing = 0;
+    let draft = 0;
+    let views = 0;
+    const episodesWithSeason: (Episode & { seasonTitle: string })[] = [];
+
+    const episodeTotal = seasons.reduce((sum, season) => sum + season.episodeCount, 0);
+
+    seasons.forEach((season) => {
+      views += season.totalViews;
+      season.episodes.forEach((episode) => {
+        episodesWithSeason.push({ ...episode, seasonTitle: season.title });
+        if (episode.status === "published") {
+          published += 1;
+        } else if (episode.status === "processing") {
+          processing += 1;
+        } else if (episode.status === "draft") {
+          draft += 1;
+        }
+      });
+    });
+
+    const highlights: EpisodeHighlight[] = episodesWithSeason
+      .filter((episode) => episode.status === "published" && episode.views > 0)
+      .sort((a, b) => b.views - a.views)
+      .slice(0, 5)
+      .map((episode) => ({
+        id: episode.id,
+        title: episode.title,
+        views: episode.views,
+        seasonTitle: episode.seasonTitle,
+      }));
+
+    const avgViews = published > 0 ? Math.round(views / published) : 0;
+
+    return {
+      totalEpisodes: episodeTotal,
+      publishedEpisodes: published,
+      processingEpisodes: processing,
+      draftEpisodes: draft,
+      totalViews: views,
+      averageViews: avgViews,
+      topEpisodes: highlights,
+    };
+  }, [seasons]);
+
+  const activeSeasons = useMemo(() => {
+    return seasons.map((season) => {
+      const publishedCount = season.episodes.filter((episode) => episode.status === "published").length;
+      const completion = season.episodeCount > 0 ? Math.round((publishedCount / season.episodeCount) * 100) : 0;
+
+      return {
+        id: season.id,
+        title: season.title,
+        description: season.description,
+        completion,
+        status: season.status,
+        startDate: season.startDate,
+      };
+    });
+  }, [seasons]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-purple-50/30">
+      <div className="flex">
+        <Sidebar collapsed={collapsed} onToggleCollapse={toggleCollapsed} />
+
+        <div className="flex-1">
+          <Header
+            title="Analytics"
+            description="Real-time performance insights across research and production"
+            status={{ label: "Updated 2m ago", color: "green", active: true }}
+            actions={
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" className="text-gray-600">
+                  <Sparkles className="w-4 h-4 mr-2" />
+                  Generate report
+                </Button>
+                <Button variant="gradient" size="sm">
+                  <LineChart className="w-4 h-4 mr-2" />
+                  View trends
+                </Button>
+              </div>
+            }
+          />
+
+          <main className="p-6 space-y-6">
+            <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+              {overviewCards.map((card) => {
+                const Icon = card.icon;
+                return (
+                  <Card key={card.label} className="relative overflow-hidden">
+                    <div className="absolute inset-0 bg-gradient-to-br from-white via-white to-purple-50/40" />
+                    <CardContent className="p-6 relative">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-medium text-gray-500">{card.label}</p>
+                          <p className="text-3xl font-semibold text-gray-900 mt-2">{card.value}</p>
+                          <p className="text-xs text-emerald-600 mt-2">{card.change}</p>
+                        </div>
+                        <div className={`w-12 h-12 rounded-xl flex items-center justify-center shadow-inner ${card.iconBg}`}>
+                          <Icon className={`w-6 h-6 ${card.iconColor}`} />
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </section>
+
+            <section className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+              <Card className="xl:col-span-2">
+                <CardHeader className="border-b border-gray-200">
+                  <CardTitle className="flex items-center gap-2">
+                    <TrendingUp className="w-5 h-5 text-purple-600" />
+                    Topic momentum
+                  </CardTitle>
+                  <p className="text-sm text-gray-600">Tracking interest growth across your core research themes</p>
+                </CardHeader>
+                <CardContent className="p-6 space-y-5">
+                  {topicMomentum.map((topic) => (
+                    <div key={topic.topic} className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-gray-900">{topic.topic}</p>
+                          <p className="text-xs text-gray-500">{topic.sentiment}</p>
+                        </div>
+                        <span className="text-xs font-medium text-emerald-600">{topic.delta}</span>
+                      </div>
+                      <div className="h-2 rounded-full bg-gray-100 overflow-hidden">
+                        <div
+                          className="h-full bg-gradient-to-r from-purple-500 to-pink-500"
+                          style={{ width: `${topic.progress}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="border-b border-gray-200">
+                  <CardTitle className="flex items-center gap-2">
+                    <Brain className="w-5 h-5 text-blue-600" />
+                    Research efficiency
+                  </CardTitle>
+                  <p className="text-sm text-gray-600">Workflow improvements driven by automation</p>
+                </CardHeader>
+                <CardContent className="p-6 space-y-4">
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-xs uppercase tracking-wide text-gray-500">Active topics</p>
+                    <p className="text-2xl font-semibold text-gray-900 mt-1">24</p>
+                    <p className="text-xs text-emerald-600 mt-1">+5 topics activated this quarter</p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-xs uppercase tracking-wide text-gray-500">Average research time</p>
+                    <p className="text-2xl font-semibold text-gray-900 mt-1">38 min</p>
+                    <p className="text-xs text-gray-500 mt-1">↓ 14 minutes compared to manual review</p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 p-4 bg-gradient-to-br from-indigo-50 to-purple-50">
+                    <p className="text-xs uppercase tracking-wide text-purple-600">Automation impact</p>
+                    <p className="text-2xl font-semibold text-purple-700 mt-1">62%</p>
+                    <p className="text-xs text-purple-600 mt-1">Of episodes created directly from AI-assisted research</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+              <Card>
+                <CardHeader className="border-b border-gray-200">
+                  <CardTitle className="flex items-center gap-2">
+                    <BarChart3 className="w-5 h-5 text-emerald-600" />
+                    Production pipeline
+                  </CardTitle>
+                  <p className="text-sm text-gray-600">Snapshot of episode progress across the studio</p>
+                </CardHeader>
+                <CardContent className="p-6 space-y-4">
+                  <div className="flex items-center justify-between text-sm text-gray-600">
+                    <span>Published episodes</span>
+                    <span className="font-semibold text-gray-900">{publishedEpisodes}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm text-gray-600">
+                    <span>In production</span>
+                    <span className="font-semibold text-gray-900">{processingEpisodes}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm text-gray-600">
+                    <span>Draft scripts</span>
+                    <span className="font-semibold text-gray-900">{draftEpisodes}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm text-gray-600">
+                    <span>Total catalog</span>
+                    <span className="font-semibold text-gray-900">{totalEpisodes}</span>
+                  </div>
+                  <div className="rounded-lg bg-gradient-to-br from-purple-500 to-pink-500 text-white p-4 mt-4">
+                    <p className="text-xs uppercase tracking-wide text-white/80">Conversion rate</p>
+                    <p className="text-2xl font-semibold mt-1">
+                      {totalEpisodes > 0 ? Math.round((publishedEpisodes / totalEpisodes) * 100) : 0}%
+                    </p>
+                    <p className="text-xs text-white/80 mt-1">of researched topics become published episodes</p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="xl:col-span-2">
+                <CardHeader className="border-b border-gray-200">
+                  <CardTitle className="flex items-center gap-2">
+                    <Users className="w-5 h-5 text-blue-600" />
+                    Audience insights
+                  </CardTitle>
+                  <p className="text-sm text-gray-600">Engagement signals aggregated from published content</p>
+                </CardHeader>
+                <CardContent className="p-6">
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="rounded-lg border border-gray-200 p-4">
+                      <p className="text-xs uppercase tracking-wide text-gray-500">Total views</p>
+                      <p className="text-2xl font-semibold text-gray-900 mt-1">{totalViews.toLocaleString()}</p>
+                      <p className="text-xs text-emerald-600 mt-1">+18.4% audience lift this quarter</p>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 p-4">
+                      <p className="text-xs uppercase tracking-wide text-gray-500">Avg views per episode</p>
+                      <p className="text-2xl font-semibold text-gray-900 mt-1">{averageViews.toLocaleString()}</p>
+                      <p className="text-xs text-gray-500 mt-1">Benchmark: 9.4K per AI-focused episode</p>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 p-4">
+                      <p className="text-xs uppercase tracking-wide text-gray-500">Top performing series</p>
+                      <p className="text-2xl font-semibold text-gray-900 mt-1">Season 1</p>
+                      <p className="text-xs text-gray-500 mt-1">Transformer deep dives keep outperforming</p>
+                    </div>
+                  </div>
+
+                  <div className="mt-6">
+                    <h3 className="text-sm font-semibold text-gray-900 mb-3">Weekly engagement</h3>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                      {engagementTimeline.map((entry) => (
+                        <div key={entry.week} className="rounded-lg border border-gray-200 p-4">
+                          <p className="text-xs uppercase tracking-wide text-gray-500">{entry.week}</p>
+                          <p className="text-lg font-semibold text-gray-900 mt-1">{entry.audience}</p>
+                          <p className="text-xs text-emerald-600 mt-1">{entry.change}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="mt-6">
+                    <h3 className="text-sm font-semibold text-gray-900 mb-3">Top performing episodes</h3>
+                    <div className="space-y-3">
+                      {topEpisodes.map((episode) => (
+                        <div key={episode.id} className="flex items-center justify-between rounded-lg border border-gray-200 p-4">
+                          <div>
+                            <p className="text-sm font-medium text-gray-900">{episode.title}</p>
+                            <p className="text-xs text-gray-500">{episode.seasonTitle}</p>
+                          </div>
+                          <div className="flex items-center text-sm font-semibold text-gray-900">
+                            {episode.views.toLocaleString()} views
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+              <Card>
+                <CardHeader className="border-b border-gray-200">
+                  <CardTitle className="flex items-center gap-2">
+                    <Sparkles className="w-5 h-5 text-purple-600" />
+                    Season health
+                  </CardTitle>
+                  <p className="text-sm text-gray-600">Track completion velocity across your production roadmap</p>
+                </CardHeader>
+                <CardContent className="p-6 space-y-4">
+                  {activeSeasons.map((season) => (
+                    <div key={season.id} className="rounded-lg border border-gray-200 p-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-gray-900">{season.title}</p>
+                          <p className="text-xs text-gray-500">{season.description}</p>
+                        </div>
+                        <span className={`text-xs font-medium ${season.status === "active" ? "text-emerald-600" : "text-gray-500"}`}>
+                          {season.status}
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-gray-100 overflow-hidden mt-3">
+                        <div
+                          className="h-full bg-gradient-to-r from-blue-500 to-purple-500"
+                          style={{ width: `${season.completion}%` }}
+                        />
+                      </div>
+                      <p className="text-xs text-gray-500 mt-2">
+                        {season.completion}% of planned episodes published · Launched {new Date(season.startDate).toLocaleDateString(undefined, { month: "short", year: "numeric" })}
+                      </p>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="border-b border-gray-200">
+                  <CardTitle className="flex items-center gap-2">
+                    <ArrowUpRight className="w-5 h-5 text-rose-500" />
+                    Next best actions
+                  </CardTitle>
+                  <p className="text-sm text-gray-600">AI-powered recommendations to sustain growth</p>
+                </CardHeader>
+                <CardContent className="p-6 space-y-4">
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-sm font-semibold text-gray-900">Double down on transformer content</p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Transformer-focused episodes drive 32% more engagement than the catalog average.
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-sm font-semibold text-gray-900">Launch interactive research recaps</p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Add short recap videos to boost completion rates on long-form discussions.
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-sm font-semibold text-gray-900">Schedule robotics spotlight</p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Robotics interest is climbing; line up a dedicated mini-series next month.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/podcast-studio/src/app/library/page.tsx
+++ b/podcast-studio/src/app/library/page.tsx
@@ -7,9 +7,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import { useSidebar } from "@/contexts/sidebar-context";
-import { 
-  Archive,
-  BookOpen, 
+import {
+  BookOpen,
   Play,
   FileText,
   Clock,
@@ -17,37 +16,10 @@ import {
   MoreHorizontal,
   Calendar,
   Users,
-  Eye,
   Edit,
   Star,
-  TrendingUp
 } from "lucide-react";
-
-interface Episode {
-  id: string;
-  title: string;
-  description: string;
-  duration: string;
-  publishDate: string;
-  status: "published" | "draft" | "processing";
-  views: number;
-  audioUrl?: string;
-  videoUrl?: string;
-  thumbnailUrl?: string;
-  featured: boolean;
-}
-
-interface Season {
-  id: string;
-  title: string;
-  description: string;
-  episodeCount: number;
-  totalViews: number;
-  startDate: string;
-  endDate?: string;
-  episodes: Episode[];
-  status: "active" | "completed";
-}
+import { defaultSeasons, type Season } from "@/data/library";
 
 export default function Library() {
   const { collapsed, toggleCollapsed } = useSidebar();
@@ -55,119 +27,9 @@ export default function Library() {
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [tab, setTab] = useState<"episodes" | "shows">("episodes");
 
-  const [seasons] = useState<Season[]>([
-    {
-      id: "1",
-      title: "Season 1: AI Fundamentals",
-      description: "Exploring foundational AI research papers and breakthroughs",
-      episodeCount: 12,
-      totalViews: 45200,
-      startDate: "2024-01-01",
-      status: "active",
-      episodes: [
-        {
-          id: "1",
-          title: "Attention Is All You Need",
-          description: "Deep dive into the transformer architecture that revolutionized AI and natural language processing",
-          duration: "24:35",
-          publishDate: "2024-01-15",
-          status: "published",
-          views: 15300,
-          audioUrl: "/audio/ep1.wav",
-          videoUrl: "/video/ep1.mp4",
-          thumbnailUrl: "/thumbnails/ep1.jpg",
-          featured: true
-        },
-        {
-          id: "2", 
-          title: "BERT: Pre-training of Deep Bidirectional Transformers",
-          description: "Understanding how BERT changed the landscape of language understanding",
-          duration: "28:42",
-          publishDate: "2024-01-22",
-          status: "published", 
-          views: 12800,
-          audioUrl: "/audio/ep2.wav",
-          videoUrl: "/video/ep2.mp4", 
-          thumbnailUrl: "/thumbnails/ep2.jpg",
-          featured: false
-        },
-        {
-          id: "3",
-          title: "GPT-3: Language Models are Few-Shot Learners",
-          description: "Exploring the capabilities and implications of large language models",
-          duration: "31:18",
-          publishDate: "2024-01-29",
-          status: "published",
-          views: 18700,
-          audioUrl: "/audio/ep3.wav",
-          videoUrl: "/video/ep3.mp4",
-          thumbnailUrl: "/thumbnails/ep3.jpg",
-          featured: true
-        },
-        {
-          id: "4",
-          title: "ResNet: Deep Residual Learning for Image Recognition",
-          description: "How residual networks solved the vanishing gradient problem",
-          duration: "26:55",
-          publishDate: "2024-02-05", 
-          status: "processing",
-          views: 0,
-          featured: false
-        },
-        {
-          id: "5",
-          title: "AlphaGo: Mastering the Game of Go with Deep Neural Networks",
-          description: "The breakthrough that demonstrated AI's potential in strategic thinking",
-          duration: "29:12",
-          publishDate: "2024-02-12",
-          status: "draft",
-          views: 0,
-          featured: false
-        }
-      ]
-    },
-    {
-      id: "2",
-      title: "Season 2: Computer Vision Revolution",
-      description: "Covering breakthrough papers in computer vision and image recognition",
-      episodeCount: 8,
-      totalViews: 32100,
-      startDate: "2024-03-01", 
-      status: "active",
-      episodes: [
-        {
-          id: "6",
-          title: "YOLO: Real-Time Object Detection",
-          description: "How YOLO changed real-time object detection forever",
-          duration: "22:30",
-          publishDate: "2024-03-08",
-          status: "published",
-          views: 9400,
-          audioUrl: "/audio/ep6.wav",
-          videoUrl: "/video/ep6.mp4",
-          thumbnailUrl: "/thumbnails/ep6.jpg",
-          featured: false
-        },
-        {
-          id: "7",
-          title: "U-Net: Convolutional Networks for Biomedical Image Segmentation",
-          description: "The architecture that revolutionized medical image analysis",
-          duration: "25:18",
-          publishDate: "2024-03-15",
-          status: "published",
-          views: 7200,
-          audioUrl: "/audio/ep7.wav",
-          videoUrl: "/video/ep7.mp4",
-          thumbnailUrl: "/thumbnails/ep7.jpg",
-          featured: false
-        }
-      ]
-    }
-  ]);
+  const [seasons] = useState<Season[]>(defaultSeasons);
 
-  const currentSeason = seasons.find(s => s.id === selectedSeason);
-  const totalEpisodes = seasons.reduce((sum, season) => sum + season.episodeCount, 0);
-  const totalViews = seasons.reduce((sum, season) => sum + season.totalViews, 0);
+  const currentSeason = seasons.find((s) => s.id === selectedSeason);
 
   const shows = useMemo(() => {
     return seasons.map((s) => ({
@@ -175,7 +37,6 @@ export default function Library() {
       title: s.title,
       description: s.description,
       episodeCount: s.episodeCount,
-      totalViews: s.totalViews,
       status: s.status,
     }));
   }, [seasons]);
@@ -212,31 +73,19 @@ export default function Library() {
             title="Your Library"
             description="All your shows and episodes, beautifully organized"
             actions={
-              <div className="flex items-center space-x-2">
-                <div className="flex items-center space-x-2 text-sm mr-2">
-                  <div className="flex items-center space-x-1">
-                    <Archive className="w-4 h-4 text-gray-400" />
-                    <span className="text-gray-600">{totalEpisodes} episodes</span>
-                  </div>
-                  <div className="flex items-center space-x-1">
-                    <Eye className="w-4 h-4 text-gray-400" />
-                    <span className="text-gray-600">{totalViews.toLocaleString()} views</span>
-                  </div>
-                </div>
-                <div className="bg-gray-100 p-1 rounded-xl flex">
-                  <button
-                    className={`px-3 py-1.5 text-sm rounded-lg transition-all ${tab === 'episodes' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}
-                    onClick={() => setTab('episodes')}
-                  >
-                    Episodes
-                  </button>
-                  <button
-                    className={`px-3 py-1.5 text-sm rounded-lg transition-all ${tab === 'shows' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}
-                    onClick={() => setTab('shows')}
-                  >
-                    Shows
-                  </button>
-                </div>
+              <div className="bg-gray-100 p-1 rounded-xl flex">
+                <button
+                  className={`px-3 py-1.5 text-sm rounded-lg transition-all ${tab === 'episodes' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}
+                  onClick={() => setTab('episodes')}
+                >
+                  Episodes
+                </button>
+                <button
+                  className={`px-3 py-1.5 text-sm rounded-lg transition-all ${tab === 'shows' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}
+                  onClick={() => setTab('shows')}
+                >
+                  Shows
+                </button>
               </div>
             }
           />
@@ -292,7 +141,9 @@ export default function Library() {
                         </p>
                         <div className="flex items-center justify-between text-xs text-gray-500">
                           <span>{season.episodeCount} episodes</span>
-                          <span>{season.totalViews.toLocaleString()} views</span>
+                          <span>
+                            Launched {new Date(season.startDate).toLocaleDateString(undefined, { month: "short", year: "numeric" })}
+                          </span>
                         </div>
                       </div>
                     ))}
@@ -304,37 +155,6 @@ export default function Library() {
                   </CardContent>
                 </Card>
 
-                {/* Stats */}
-                <Card className="mt-6">
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <TrendingUp className="w-5 h-5 text-blue-600" />
-                      <span>Statistics</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-3">
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-gray-600">Total Episodes:</span>
-                      <span className="font-semibold text-gray-900">{totalEpisodes}</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-gray-600">Total Views:</span>
-                      <span className="font-semibold text-gray-900">{totalViews.toLocaleString()}</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-gray-600">Published:</span>
-                      <span className="font-semibold text-green-600">
-                        {seasons.reduce((sum, s) => sum + s.episodes.filter(e => e.status === 'published').length, 0)}
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-gray-600">In Progress:</span>
-                      <span className="font-semibold text-yellow-600">
-                        {seasons.reduce((sum, s) => sum + s.episodes.filter(e => e.status === 'processing').length, 0)}
-                      </span>
-                    </div>
-                  </CardContent>
-                </Card>
               </div>
 
               {/* Episodes/Shows Area */}
@@ -391,12 +211,6 @@ export default function Library() {
                                         <span>{episode.duration}</span>
                                         <span>{new Date(episode.publishDate).toLocaleDateString()}</span>
                                       </div>
-                                      {episode.status === 'published' && (
-                                        <div className="flex items-center space-x-1 text-xs text-gray-500 mb-3">
-                                          <Eye className="w-3 h-3" />
-                                          <span>{episode.views.toLocaleString()} views</span>
-                                        </div>
-                                      )}
                                       <div className="flex items-center space-x-2">
                                         {episode.status === 'published' && (
                                           <>
@@ -453,12 +267,6 @@ export default function Library() {
                                 <div className="flex items-center space-x-4 text-xs text-gray-500">
                                   <span>{episode.duration}</span>
                                   <span>{new Date(episode.publishDate).toLocaleDateString()}</span>
-                                  {episode.status === 'published' && (
-                                    <div className="flex items-center space-x-1">
-                                      <Eye className="w-3 h-3" />
-                                      <span>{episode.views.toLocaleString()}</span>
-                                    </div>
-                                  )}
                                 </div>
                                 <div className="flex items-center space-x-1">
                                   {episode.status === 'published' && (
@@ -498,7 +306,7 @@ export default function Library() {
                                   </div>
                                   <div className="flex items-center justify-between text-xs text-gray-500 mt-3">
                                     <span>{show.episodeCount} episodes</span>
-                                    <span>{show.totalViews.toLocaleString()} views</span>
+                                    <span>{show.status === "active" ? "New episodes in production" : "Season archived"}</span>
                                   </div>
                                 </div>
                               </CardContent>

--- a/podcast-studio/src/app/page.tsx
+++ b/podcast-studio/src/app/page.tsx
@@ -13,12 +13,11 @@ import {
   Brain,
   Eye,
   Cpu,
-  Settings, 
+  Settings,
   Search,
   Play,
   FileText,
   Sparkles,
-  TrendingUp,
   Clock,
   Users
 } from "lucide-react";
@@ -61,13 +60,6 @@ const topics = [
     borderColor: "border-orange-200",
     description: "Robotic systems and automation"
   },
-];
-
-const stats = [
-  { label: "Papers Analyzed", value: "1,247", icon: BookOpen, color: "text-purple-600" },
-  { label: "Episodes Created", value: "89", icon: Brain, color: "text-blue-600" },
-  { label: "Total Views", value: "12.4K", icon: TrendingUp, color: "text-green-600" },
-  { label: "Research Hours", value: "156", icon: Clock, color: "text-orange-600" },
 ];
 
 interface PaperApi {
@@ -262,28 +254,6 @@ export default function Home() {
           />
 
           <main className="p-6 space-y-8">
-            {/* Stats Overview */}
-            <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-              {stats.map((stat, index) => {
-                const IconComponent = stat.icon;
-                return (
-                  <Card key={index} className="animate-fade-in" style={{ animationDelay: `${index * 100}ms` }}>
-                    <CardContent className="p-6">
-                      <div className="flex items-center space-x-4">
-                        <div className={`w-12 h-12 rounded-xl bg-gray-50 flex items-center justify-center`}>
-                          <IconComponent className={`w-6 h-6 ${stat.color}`} />
-                        </div>
-                        <div>
-                          <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
-                          <p className="text-sm text-gray-600">{stat.label}</p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
-            </section>
-
             {/* Topic Selection */}
             <section className="animate-slide-up">
               <Card>

--- a/podcast-studio/src/components/layout/sidebar.tsx
+++ b/podcast-studio/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Headphones,
   Menu,
   X,
+  LineChart,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -35,6 +36,13 @@ const navigation: NavigationItem[] = [
     href: "/",
     icon: Search,
     description: "Discover research papers",
+    badge: null,
+  },
+  {
+    name: "Analytics",
+    href: "/analytics",
+    icon: LineChart,
+    description: "Track performance insights",
     badge: null,
   },
   {

--- a/podcast-studio/src/data/library.ts
+++ b/podcast-studio/src/data/library.ts
@@ -1,0 +1,136 @@
+export interface Episode {
+  id: string;
+  title: string;
+  description: string;
+  duration: string;
+  publishDate: string;
+  status: "published" | "draft" | "processing";
+  views: number;
+  audioUrl?: string;
+  videoUrl?: string;
+  thumbnailUrl?: string;
+  featured: boolean;
+}
+
+export interface Season {
+  id: string;
+  title: string;
+  description: string;
+  episodeCount: number;
+  totalViews: number;
+  startDate: string;
+  endDate?: string;
+  episodes: Episode[];
+  status: "active" | "completed";
+}
+
+export const defaultSeasons: Season[] = [
+  {
+    id: "1",
+    title: "Season 1: AI Fundamentals",
+    description: "Exploring foundational AI research papers and breakthroughs",
+    episodeCount: 12,
+    totalViews: 45200,
+    startDate: "2024-01-01",
+    status: "active",
+    episodes: [
+      {
+        id: "1",
+        title: "Attention Is All You Need",
+        description:
+          "Deep dive into the transformer architecture that revolutionized AI and natural language processing",
+        duration: "24:35",
+        publishDate: "2024-01-15",
+        status: "published",
+        views: 15300,
+        audioUrl: "/audio/ep1.wav",
+        videoUrl: "/video/ep1.mp4",
+        thumbnailUrl: "/thumbnails/ep1.jpg",
+        featured: true,
+      },
+      {
+        id: "2",
+        title: "BERT: Pre-training of Deep Bidirectional Transformers",
+        description: "Understanding how BERT changed the landscape of language understanding",
+        duration: "28:42",
+        publishDate: "2024-01-22",
+        status: "published",
+        views: 12800,
+        audioUrl: "/audio/ep2.wav",
+        videoUrl: "/video/ep2.mp4",
+        thumbnailUrl: "/thumbnails/ep2.jpg",
+        featured: false,
+      },
+      {
+        id: "3",
+        title: "GPT-3: Language Models are Few-Shot Learners",
+        description: "Exploring the capabilities and implications of large language models",
+        duration: "31:18",
+        publishDate: "2024-01-29",
+        status: "published",
+        views: 18700,
+        audioUrl: "/audio/ep3.wav",
+        videoUrl: "/video/ep3.mp4",
+        thumbnailUrl: "/thumbnails/ep3.jpg",
+        featured: true,
+      },
+      {
+        id: "4",
+        title: "ResNet: Deep Residual Learning for Image Recognition",
+        description: "How residual networks solved the vanishing gradient problem",
+        duration: "26:55",
+        publishDate: "2024-02-05",
+        status: "processing",
+        views: 0,
+        featured: false,
+      },
+      {
+        id: "5",
+        title: "AlphaGo: Mastering the Game of Go with Deep Neural Networks",
+        description: "The breakthrough that demonstrated AI's potential in strategic thinking",
+        duration: "29:12",
+        publishDate: "2024-02-12",
+        status: "draft",
+        views: 0,
+        featured: false,
+      },
+    ],
+  },
+  {
+    id: "2",
+    title: "Season 2: Computer Vision Revolution",
+    description: "Covering breakthrough papers in computer vision and image recognition",
+    episodeCount: 8,
+    totalViews: 32100,
+    startDate: "2024-03-01",
+    status: "active",
+    episodes: [
+      {
+        id: "6",
+        title: "YOLO: Real-Time Object Detection",
+        description: "How YOLO changed real-time object detection forever",
+        duration: "22:30",
+        publishDate: "2024-03-08",
+        status: "published",
+        views: 9400,
+        audioUrl: "/audio/ep6.wav",
+        videoUrl: "/video/ep6.mp4",
+        thumbnailUrl: "/thumbnails/ep6.jpg",
+        featured: false,
+      },
+      {
+        id: "7",
+        title: "U-Net: Convolutional Networks for Biomedical Image Segmentation",
+        description: "The architecture that revolutionized medical image analysis",
+        duration: "25:18",
+        publishDate: "2024-03-15",
+        status: "published",
+        views: 7200,
+        audioUrl: "/audio/ep7.wav",
+        videoUrl: "/video/ep7.mp4",
+        thumbnailUrl: "/thumbnails/ep7.jpg",
+        featured: false,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add a dedicated analytics dashboard that visualizes research and production performance with branded cards and insights
- extract library season data for reuse and remove analytics counters from the research hub and episode library pages
- update sidebar navigation to surface the new analytics route alongside the existing studio workflow

## Testing
- npm run lint *(fails: existing realtime API routes trigger no-explicit-any warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cafca03ff0832ea4a2a48e1342105b