### PR TITLE
Fix analytics metrics and reposition sidebar link

### DIFF
--- a/podcast-studio/src/app/analytics/page.tsx
+++ b/podcast-studio/src/app/analytics/page.tsx
@@ -129,17 +129,16 @@ export default function AnalyticsPage() {
     let published = 0;
     let processing = 0;
     let draft = 0;
-    let views = 0;
+    let publishedViews = 0;
     const episodesWithSeason: (Episode & { seasonTitle: string })[] = [];
 
-    const episodeTotal = seasons.reduce((sum, season) => sum + season.episodeCount, 0);
-
     seasons.forEach((season) => {
-      views += season.totalViews;
       season.episodes.forEach((episode) => {
         episodesWithSeason.push({ ...episode, seasonTitle: season.title });
+
         if (episode.status === "published") {
           published += 1;
+          publishedViews += episode.views;
         } else if (episode.status === "processing") {
           processing += 1;
         } else if (episode.status === "draft") {
@@ -147,6 +146,8 @@ export default function AnalyticsPage() {
         }
       });
     });
+
+    const totalEpisodeCount = episodesWithSeason.length;
 
     const highlights: EpisodeHighlight[] = episodesWithSeason
       .filter((episode) => episode.status === "published" && episode.views > 0)
@@ -159,14 +160,14 @@ export default function AnalyticsPage() {
         seasonTitle: episode.seasonTitle,
       }));
 
-    const avgViews = published > 0 ? Math.round(views / published) : 0;
+    const avgViews = published > 0 ? Math.round(publishedViews / published) : 0;
 
     return {
-      totalEpisodes: episodeTotal,
+      totalEpisodes: totalEpisodeCount,
       publishedEpisodes: published,
       processingEpisodes: processing,
       draftEpisodes: draft,
-      totalViews: views,
+      totalViews: publishedViews,
       averageViews: avgViews,
       topEpisodes: highlights,
     };

--- a/podcast-studio/src/components/layout/sidebar.tsx
+++ b/podcast-studio/src/components/layout/sidebar.tsx
@@ -39,13 +39,6 @@ const navigation: NavigationItem[] = [
     badge: null,
   },
   {
-    name: "Analytics",
-    href: "/analytics",
-    icon: LineChart,
-    description: "Track performance insights",
-    badge: null,
-  },
-  {
     name: "Audio Studio",
     href: "/studio",
     icon: Mic,
@@ -72,6 +65,13 @@ const navigation: NavigationItem[] = [
     icon: Archive,
     description: "Manage episodes",
     badge: "12",
+  },
+  {
+    name: "Analytics",
+    href: "/analytics",
+    icon: LineChart,
+    description: "Track performance insights",
+    badge: null,
   },
 ];
 


### PR DESCRIPTION
## Summary
- align analytics KPIs with actual episode data to remove planned vs actual mismatches
- calculate average and total views from published episodes only while keeping highlights intact
- move the Analytics entry to the bottom of the sidebar navigation

## Testing
- npm run lint *(fails: existing violations in realtime API routes unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb13212e8c832e90d0f5dbc158ec41