### PR TITLE
Improve realtime studio conversation flow and context

### DIFF
--- a/podcast-studio/src/contexts/AGENT.md
+++ b/podcast-studio/src/contexts/AGENT.md
@@ -20,17 +20,19 @@ src/contexts/
   `collapsed` and `toggleCollapsed` directly.
 
 ## API Config Context
-- `ApiConfigProvider` persists the user's chosen LLM provider (`openai` or `google`), API keys,
-  and optional model overrides to `localStorage` under `vps:llmConfig`.
+- `ApiConfigProvider` persists the user's chosen LLM provider (`openai` or `google`) and optional
+  model overrides to `localStorage` under `vps:llmConfig`. API keys are kept in-memory only so they
+  are never written to persistent browser storage.
 - Hydration flow:
   1. On mount, attempt to read and parse the stored JSON.
   2. `hasHydrated` guards against writing back until the initial read completes.
-  3. Any state mutation (provider, key, model) re-serializes to `localStorage`.
+  3. Any provider/model mutation re-serializes to `localStorage`; key updates stay in volatile state
+     for security.
 - Consumers (`useApiConfig`) receive `{ activeProvider, apiKeys, models, setActiveProvider,
   setApiKey, clearApiKey, setModel }`.
 - The Audio Studio relies on this context to gate `/api/rt/start` calls. Maintain the guard that
   falls back to the environment `OPENAI_API_KEY` only on the server—client components should
-  always respect the user-specified keys.
+  always respect the user-specified keys provided during the current session.
 
 ## Implementation Tips
 - Keep both providers client components (they access browser storage). Mark new providers with

--- a/podcast-studio/src/lib/conversationStorage.ts
+++ b/podcast-studio/src/lib/conversationStorage.ts
@@ -19,6 +19,7 @@ export interface StoredConversationMessage {
   timestamp: string;
   speaker?: string;
   type: "text" | "audio";
+  order?: number;
 }
 
 export interface StoredConversationAudioTrack {


### PR DESCRIPTION
## Summary
- implement a client-side ZIP helper and message ordering so live transcripts, audio capture, and downloads stay available after disconnects
- keep OpenAI API keys in volatile state only and update the agent guide while adding paper context passthrough in `/api/rt/start`
- enrich the realtime session manager with paper-aware instructions, safer event typing, and conversation caching for video studio handoff

## Testing
- `npm run lint` *(fails: existing @typescript-eslint/no-explicit-any violations across legacy API routes)*
- `npm run build` *(fails: Next.js could not reach Google Fonts in the containerized environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2decd25c832ebdea65de487f1818