### PR TITLE
Improve studio context handoff and live transcription UX

### DIFF
--- a/podcast-studio/src/app/studio/page.tsx
+++ b/podcast-studio/src/app/studio/page.tsx
@@ -1125,7 +1125,8 @@ export default function Studio() {
       setSessionDuration(0);
       setIsConnected(true);
       setIsSessionReady(true);
-      setUserTranscription('');
+      setIsUserSpeaking(false);
+      setUserTranscriptionDisplay('');
       setIsTranscribing(false);
 
       console.log('[INFO] Connection successful - ready for conversation');

--- a/podcast-studio/src/components/ui/scroll-area.tsx
+++ b/podcast-studio/src/components/ui/scroll-area.tsx
@@ -5,13 +5,13 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
-function ScrollArea({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentProps<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => {
   return (
     <ScrollAreaPrimitive.Root
+      ref={ref}
       data-slot="scroll-area"
       className={cn("relative", className)}
       {...props}
@@ -26,7 +26,9 @@ function ScrollArea({
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )
-}
+})
+
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 
 function ScrollBar({
   className,


### PR DESCRIPTION
## Summary
- ensure the studio data channel sends paper-derived instructions so the AI respects the selected research context
- add animated live transcription feedback for the host and highlight active AI responses with a typing caret
- keep the transcript viewport pinned by scrolling its container instead of the entire page and expose a ref-enabled ScrollArea

## Testing
- `npm run lint` *(fails: existing realtime API routes still use `any` and prefer-const patterns upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68cc360097f4832eb6f1ab4f40b5a24f