### PR TITLE
Fix reset transcription callback initialization order

### DIFF
--- a/podcast-studio/src/app/studio/page.tsx
+++ b/podcast-studio/src/app/studio/page.tsx
@@ -378,6 +378,15 @@ export default function Studio() {
     }
   }, []);
 
+  const resetUserTranscriptionState = useCallback(() => {
+    userPendingTextRef.current = '';
+    setUserTranscriptionDisplay('');
+    stopUserTyping();
+    updateIsUserSpeaking(false);
+    setIsTranscribing(false);
+    currentUserMessageRef.current = null;
+  }, [stopUserTyping, updateIsUserSpeaking]);
+
   const startUserTyping = useCallback(() => {
     if (typeof window === 'undefined') {
       return;
@@ -861,15 +870,6 @@ export default function Studio() {
     aiTextBufferRef.current += text;
     startAiTyping();
   }, [startAiTyping]);
-
-  const resetUserTranscriptionState = useCallback(() => {
-    userPendingTextRef.current = '';
-    setUserTranscriptionDisplay('');
-    stopUserTyping();
-    updateIsUserSpeaking(false);
-    setIsTranscribing(false);
-    currentUserMessageRef.current = null;
-  }, [stopUserTyping, updateIsUserSpeaking]);
 
   const handleUserTranscriptionStarted = useCallback(() => {
     if (!isUserSpeakingRef.current) {


### PR DESCRIPTION
## Summary
- move `resetUserTranscriptionState` earlier in `Studio` so its cleanup effect can access the callback without hitting the temporal dead zone
- keep all existing references intact while preserving the transcription reset behavior

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cc6af66ed4832ea6bb5b88e5907892