### PR TITLE
docs: refresh agent guides and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,225 +1,142 @@
 # 🎙️ Virtual Podcast Studio
 
-A modern web application for discovering and analyzing research papers from arXiv to create AI-powered podcast content with real-time voice conversations.
+A full-stack workspace for turning research papers into AI-assisted podcast episodes. The project
+combines a FastAPI backend for arXiv ingestion + realtime OpenAI bridging with a Next.js frontend
+that guides creators from discovery through post-production.
 
-## 🚀 Quick Start
+## ✨ Key Capabilities
+- **Research Hub** – Accessible topic toggles, deduplicated arXiv results, and a handoff flow that
+  persists the selected paper to the Audio Studio.
+- **Audio Studio** – WebRTC microphone capture, realtime responses from OpenAI via custom API routes,
+  live transcripts/audio streams, and export options (transcript download, WAV/ZIP bundle).
+- **Post-production dashboards** – Video Studio timeline editor, Library, Publisher, and Analytics
+  pages that consume saved conversations for mock editing/publishing workflows.
+- **Workspace settings** – Sidebar collapse state and API provider/credential management stored via
+  React contexts, with localStorage hydration for persistent preferences.
+
+## 📁 Repository Structure
+
+| Path | Description |
+| --- | --- |
+| `backend/` | FastAPI app (`main.py`) with `/api/papers`, `/health`, and `/ws/conversation` endpoints plus OpenAI realtime bridge. |
+| `podcast-studio/` | Next.js 15 App Router frontend (Research Hub, Audio Studio, Video Studio, Library, Publisher, Analytics, realtime API routes). |
+| `quick_health_check.py` | CLI helper that verifies `backend/.env` includes `OPENAI_API_KEY` and confirms the FastAPI `/health` endpoint is reachable. |
+| `README.md` | This guide. |
+
+## 🔄 Architecture at a Glance
+1. **Topic discovery** – The Research Hub posts to `POST /api/papers`. A Next.js proxy validates the
+   payload and forwards it to FastAPI, which sanitises each topic, queries arXiv, de-duplicates
+   results, and returns the newest papers first.
+2. **Realtime session** – The Audio Studio starts a session via `POST /api/rt/start`, negotiates
+   WebRTC with `/api/rt/webrtc`, streams microphone PCM chunks through `/api/rt/audio-append` +
+   `/api/rt/audio-commit`, and listens to Server-Sent Events for assistant audio (`/audio`) and
+   transcripts (`/transcripts`, `/user-transcripts`). A legacy WebSocket fallback remains available at
+   `backend/ws/conversation`.
+3. **Conversation storage** – Finished sessions are serialised with
+   `src/lib/conversationStorage.ts`, saved in `sessionStorage`, and consumed by the Video Studio,
+   Library, and Publisher pages.
+
+```
+Browser (Research Hub & Studios)
+   │  fetch /api/papers
+   ▼
+Next.js API route ──► FastAPI (`/api/papers`) ──► arXiv API
+   │
+   ├─► Realtime routes (`/api/rt/*`) ──► RT session manager ──► OpenAI Realtime
+   └─► sessionStorage (selected paper / saved conversation)
+```
+
+## ⚙️ Setup
 
 ### Prerequisites
-
-- **Node.js 18+** (20+ preferred)
+- **Node.js 18+** (20 recommended)
 - **Python 3.8+**
-- **OpenAI API Key** with Realtime API access
+- **OpenAI API key** with access to the Realtime API
 
-### 1. Clone and Setup
-
+### 1. Configure Environment Variables
+Create `backend/.env` with at least:
 ```bash
-git clone <repository-url>
-cd virtualpodcaststudio
+OPENAI_API_KEY=sk-...
+# Optional: ALLOWED_ORIGINS, OPENAI_REALTIME_MODEL, OPENAI_REALTIME_VOICE
 ```
 
-### 2. Backend Setup
-
+Create `podcast-studio/.env.local` with (if you want to provide a server-side fallback key or custom
+endpoints):
 ```bash
+OPENAI_API_KEY=sk-...          # used only by Next.js API routes when the user has not provided one
+# Optional: OPENAI_REALTIME_MODEL, OPENAI_REALTIME_VOICE
+# Optional: BACKEND_URL, NEXT_PUBLIC_BACKEND_URL (default http://localhost:8000)
+```
+
+### 2. Install Dependencies
+```bash
+# Backend
 cd backend
 python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+source venv/bin/activate  # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 
-# Add your OpenAI API key
-echo "OPENAI_API_KEY=your_key_here" > .env
-```
-
-### 3. Frontend Setup
-
-```bash
-cd podcast-studio
+# Frontend
+cd ../podcast-studio
 npm install
 ```
 
-### 4. Start the Application
-
-**Terminal 1 - Backend:**
+### 3. Run the Stack
 ```bash
+# Terminal 1 – FastAPI backend
 cd backend
 source venv/bin/activate
 uvicorn main:app --host 0.0.0.0 --port 8000 --reload
-```
 
-**Terminal 2 - Frontend:**
-```bash
+# Terminal 2 – Next.js frontend
 cd podcast-studio
 npm run dev
 ```
+Visit **http://localhost:3000/studio** to open the Audio Studio (or `/` for the Research Hub).
 
-**Visit:** `http://localhost:3000/studio` to start your AI-powered podcast session!
+### 4. Quick Health Check
+Run `python quick_health_check.py` from the repo root to verify the backend is running and the
+OpenAI key is configured. The frontend also exposes `GET /api/test-openai` to confirm credentials can
+list models.
 
-## ✨ Features
+## 🧠 Realtime Workflow Cheat Sheet
+1. Select a paper in the Research Hub. The card’s “Start Audio Studio” button stores the selection in
+   `sessionStorage` and navigates to `/studio`.
+2. In the Audio Studio, open the workspace settings sheet to provide API credentials (if you do not
+   want to rely on server-side keys) and click **Connect**.
+3. When ready, click **Start Voice Recording**. Microphone audio is chunked to
+   `/api/rt/audio-append`, committed via `/api/rt/audio-commit`, and streamed back as AI audio/text.
+4. Use the controls on the right to export transcripts, download audio bundles, or send the session to
+   the Video Studio for post-production.
+5. Disconnect when finished—this stops microphone capture, tears down the WebRTC session, and saves
+   the conversation for downstream pages.
 
-### 🎤 Real-time Voice Conversations
-- **AI-Powered Host**: Dr. Sarah, an expert AI researcher
-- **Live Transcription**: Real-time speech-to-text
-- **Voice Responses**: Natural AI voice synthesis
-- **WebSocket Communication**: Low-latency real-time interaction
+## 🧪 Development Scripts
 
-### 📚 Research Paper Integration
-- **arXiv API**: Fetch latest research papers
-- **Multi-Topic Selection**: AI, Physics, Math, Computer Vision, Robotics
-- **Paper Analysis**: AI discusses and explains research findings
-- **Topic Filtering**: Focus on specific research areas
+| Location | Command | Purpose |
+| --- | --- | --- |
+| `podcast-studio/` | `npm run dev` | Start the Next.js dev server (Turbopack). |
+|  | `npm run build` | Verify the production bundle. |
+|  | `npm run lint` | Run ESLint (flat config). |
+|  | `npm run start` | Serve the production build. |
+| `backend/` | `uvicorn main:app --reload` | Run the FastAPI server with auto-reload. |
+| Repo root | `python quick_health_check.py` | Validate configuration + backend health. |
 
-### 🎨 Modern Interface
-- **Dark Theme**: Professional GarageBand-inspired design
-- **Responsive Layout**: Works on desktop and mobile
-- **Real-time Status**: Connection and recording indicators
-- **Clean UI**: Intuitive user experience
-
-## 🏗️ Architecture
-
-```mermaid
-graph TB
-    A[User Browser] --> B[Next.js Frontend]
-    B --> C[FastAPI Backend]
-    C --> D[OpenAI Realtime API]
-    C --> E[arXiv API]
-    
-    B --> F[WebSocket Connection]
-    C --> F
-    
-    D --> G[AI Voice Synthesis]
-    D --> H[Speech Recognition]
-    E --> I[Research Papers]
-```
-
-### Tech Stack
-- **Frontend**: Next.js 15, TypeScript, Tailwind CSS, Shadcn/UI
-- **Backend**: FastAPI, WebSocket, OpenAI Realtime API
-- **APIs**: arXiv API, OpenAI Realtime API
-- **Real-time**: WebSocket connections for low-latency communication
-
-## 📡 API Endpoints
-
-### Health Check
-```http
-GET /health
-```
-
-### Research Papers
-```http
-POST /api/papers
-Content-Type: application/json
-
-{
-  "topics": ["cs.AI", "cs.CV", "cs.LG"]
-}
-```
-
-### WebSocket Conversation
-```http
-WS /ws/conversation
-```
-
-**Message Types:**
-- `{type: "audio", audio: "base64_data"}` - Voice input
-- `{type: "text", text: "message"}` - Text input
-- `{type: "session_ready"}` - Connection established
-- `{type: "audio_delta", audio: "base64_data"}` - Streaming AI audio
-- `{type: "text_delta", text: "partial_text"}` - Streaming AI text
-
-## 🎯 Available Research Topics
-
-| Topic Code | Description |
-|------------|-------------|
-| `cs.AI` | Artificial Intelligence |
-| `cs.LG` | Machine Learning |
-| `cs.CV` | Computer Vision |
-| `cs.RO` | Robotics |
-| `cs.CL` | Computation and Language |
-| `cs.CR` | Cryptography and Security |
-| `cs.DC` | Distributed Computing |
-| `cs.DB` | Databases |
-
-## 🔧 Development
-
-### Frontend Commands
-```bash
-npm run dev          # Development server
-npm run build        # Production build
-npm run start        # Production server
-npm run lint         # Code linting
-npm run format       # Format with Prettier
-```
-
-### Backend Commands
-```bash
-uvicorn main:app --reload              # Development server
-uvicorn main:app --host 0.0.0.0 --port 8000  # Production server
-```
-
-### Environment Variables
-
-**Backend (.env):**
-```bash
-OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_REALTIME_MODEL=gpt-realtime
-OPENAI_REALTIME_VOICE=alloy
-```
-
-## 🎙️ How to Use
-
-1. **Start the Application**: Follow the Quick Start guide above
-2. **Navigate to Studio**: Go to `http://localhost:3000/studio`
-3. **Wait for Connection**: Status will show "CONNECTING" then "READY"
-4. **Start Conversation**:
-   - **Voice**: Click "Start Voice Recording" and speak
-   - **Text**: Type a message and press Enter
-5. **AI Response**: Dr. Sarah will respond with both voice and text
-6. **Live Transcription**: Your speech appears in real-time
-
-## 🐛 Troubleshooting
-
-### Common Issues
-
-**Backend not starting:**
-- Check if port 8000 is available
-- Verify Python virtual environment is activated
-- Ensure all dependencies are installed
-
-**Frontend not connecting:**
-- Verify backend is running on port 8000
-- Check browser console for WebSocket errors
-- Ensure CORS is properly configured
-
-**No AI response:**
-- Verify OpenAI API key is valid
-- Check account has Realtime API access
-- Ensure sufficient API credits
-
-**Audio issues:**
-- Allow microphone permissions in browser
-- Check audio device is working
-- Verify WebSocket connection is stable
-
-### Debug Mode
-
-Enable detailed logging by checking browser DevTools → Console for emoji-marked logs:
-- 🔌 Connection status
-- 🎤 Audio processing
-- 💬 AI responses
-- ✅ Success indicators
-- ❌ Error messages
-
-## 📚 Documentation
-
-All essential setup, usage, troubleshooting, and architecture information is covered in this README. Refer to the sections above for Quick Start, Features, Architecture, API Endpoints, Environment Variables, and Troubleshooting.
+## 🛠️ Troubleshooting
+- **Backend not reachable** – Ensure `uvicorn` is running on port 8000. If you changed the port,
+  update `BACKEND_URL` / `NEXT_PUBLIC_BACKEND_URL`.
+- **Realtime session errors** – Confirm `/api/rt/start` returns `{ ok: true }` in the network tab and
+  that your API key has access to OpenAI Realtime. Missing keys surface as HTTP 400/503 responses.
+- **No audio or transcript** – Check browser microphone permissions and verify SSE endpoints (audio,
+  transcripts, user transcripts) are open in the network inspector.
+- **Workspace settings not persisting** – Only provider + model selections persist via localStorage.
+  API keys intentionally reset on refresh for security.
 
 ## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test thoroughly
-5. Submit a pull request
+1. Fork the repository and create a feature branch (no force pushes to `main`).
+2. Keep backend/frontend schemas in sync and update the relevant `AGENT.md` + README sections.
+3. Run `npm run lint` and exercise the realtime workflow before opening a PR.
+4. Submit the PR with a clear summary of changes.
 
 ## 📄 License
-
-MIT License - see LICENSE file for details
+MIT License – see [LICENSE](./LICENSE) for details.

--- a/backend/AGENT.md
+++ b/backend/AGENT.md
@@ -1,93 +1,70 @@
 # Backend Agent Guide
 
-## Overview
-The backend is a single FastAPI application defined in [`main.py`](./main.py). It exposes
-REST and WebSocket endpoints that either proxy to arXiv for research papers or bridge a
-browser client to OpenAI's Realtime API. Everything runs inside one module, so edits in
-this file affect the entire service.
+## Structure
+Everything lives in [`main.py`](./main.py). The module defines the FastAPI application,
+rate-limiter, arXiv client utilities, and the realtime WebSocket bridge. There are no
+additional packages—changes to this file impact the entire backend.
 
 ```
 backend/
 ├── main.py            # FastAPI app, models, realtime bridge, rate limiter
-├── requirements.txt   # Python dependencies (FastAPI, httpx, websockets, etc.)
+├── requirements.txt   # Dependency pins (FastAPI, httpx, feedparser, websockets, etc.)
 └── AGENT.md           # This guide
 ```
 
-## Runtime Building Blocks
-- **FastAPI app** – created at module import, configured with CORS middleware using the
-  `ALLOWED_ORIGINS` environment variable.
-- **Rate limiting** – `check_rate_limit` keeps a per-IP sliding window (100 requests in
-  60 seconds) shared by both HTTP and WebSocket handlers. Respect it when adding new
-  entry points.
-- **Pydantic models** – `PaperRequest`, `Paper`, and `PaperResponse` define the schema
-  shared with the frontend.
-- **RealtimeSession** – lightweight bridge that connects the client WebSocket to
-  `wss://api.openai.com/v1/realtime`, relays audio/text events, and pushes typing/speech
-  markers back to the browser.
+## Core Components
+- **FastAPI app** – Created at import time, configured with CORS based on the
+  `ALLOWED_ORIGINS` environment variable (defaults to `http://localhost:3000`).
+- **Rate limiting** – `check_rate_limit` stores timestamps per client IP (100 requests in a
+  60 second window). It guards both HTTP routes and the WebSocket endpoint.
+- **Data models** – `PaperRequest`, `Paper`, and `PaperResponse` describe the payload shared
+  with the frontend. Validation mirrors the Next.js proxy route and enforces length/character
+  constraints.
+- **Input helpers** – `sanitize_input` trims and whitelists topic strings; `format_authors`
+  condenses the author list (first three + “et al.”) for card display.
+- **ArXiv ingestion** – `fetch_arxiv_papers` loops through topics, builds Atom queries,
+  fetches results with `httpx.AsyncClient`, normalises metadata, then de-duplicates and sorts
+  by the `published` timestamp before truncating to the requested maximum.
+- **Realtime bridge** – `RealtimeSession` owns the outbound WebSocket to OpenAI. It sends an
+  initial `session.update` payload (`modalities` text+audio, Whisper transcription, server VAD),
+  forwards user audio/text inputs as `conversation.item.create` events, triggers
+  `response.create`, and relays downstream events (`session_ready`, audio/text deltas, speech
+  start/stop) back to the browser WebSocket client.
 
-## Endpoints & Flow
+## Endpoints
 | Path | Handler | Notes |
 | --- | --- | --- |
-| `GET /` | `root` | Simple health banner. |
-| `GET /health` | `health_check` | Returns `{status, timestamp}` for readiness probes. |
-| `POST /api/papers` | `fetch_papers` | Validates topic payload, rate-limits by IP, calls `fetch_arxiv_papers`, de-duplicates, sorts, and returns up to 10 results. |
-| `WS /ws/conversation` | `websocket_conversation` | Accepts JSON messages with `{type: 'audio'|'text'}` and proxies them to OpenAI. Emits deltas for audio/text plus speech boundary events. |
+| `GET /` | `root` | Simple JSON banner indicating the API is running. |
+| `GET /health` | `health_check` | Returns `{status, timestamp}` for readiness checks. |
+| `POST /api/papers` | `fetch_papers` | Validates topics, applies rate limiting, calls `fetch_arxiv_papers`, and returns the deduped, sorted list. |
+| `WS /ws/conversation` | `websocket_conversation` | Legacy realtime bridge. Ensures rate-limit compliance, connects to OpenAI, relays audio/text events, and tears down the OpenAI socket on disconnect. |
 
-### Paper fetching workflow
-1. Input is validated twice: Pydantic (`PaperRequest.topics`) and `sanitize_input` to
-   strip invalid characters and enforce a 50-character limit.
-2. For each topic we build an Atom query and fetch with `httpx.AsyncClient`. This is done
-   sequentially inside an `async` loop; if you add concurrency, reuse a single client and
-   keep timeouts at 30s or lower.
-3. `feedparser` turns the Atom feed into entries. We canonicalize authors, trim abstracts,
-   and track the most recent publication dates.
-4. Duplicate IDs are removed before sorting by `published` descending. The result list is
-   truncated to `max_results` (defaults to 10) so the frontend never receives more than it
-   expects.
-5. Errors raise HTTP 503 for upstream failures or 500 for unknown issues. Keep error text
-   generic—frontend surfaces the message to end users.
+## Implementation Notes
+- Keep handlers **async**; avoid blocking operations inside routes or WebSocket loops.
+- Mirror validation logic with the frontend proxy. Schema changes must be coordinated with
+  `src/app/api/papers/route.ts`, the Research Hub, and the Audio Studio’s stored paper shape.
+- `RealtimeSession` stores its configuration on instantiation. If you alter session defaults
+  (voice, modalities, transcription), update the Audio Studio so it expects the same
+  capabilities.
+- Always close the OpenAI socket in `RealtimeSession.close()` (the websocket route calls this
+  in a `finally` block). If you add background tasks, cancel them when the client disconnects.
+- Logging uses the module-level `logger`. Keep messages informative without exposing secrets or
+  dumping large payloads.
 
-### Realtime workflow
-1. Each WebSocket client gets its own `RealtimeSession`. The OpenAI API key is read from
-   `OPENAI_API_KEY`; abort early if it is missing.
-2. On connect we immediately send a `session.update` event that sets modalities,
-   transcription, voice, and server-side VAD config. Update this payload carefully—browser
-   code assumes both text and audio are enabled.
-3. Incoming client messages:
-   - `{type: 'audio', audio: <base64 PCM16>}` → `conversation.item.create` with
-     `input_audio` content followed by `response.create`.
-   - `{type: 'text', text: string}` → same flow with `input_text`.
-4. Downstream messages from OpenAI are streamed back to the browser as JSON events:
-   `session_ready`, `audio_delta`, `text_delta`, `response_done`, `speech_started`, and
-   `speech_stopped`. When extending, coordinate any new event names with the frontend
-   WebSocket client (`useRealtimeConversation`).
-5. `websocket_conversation` keeps an asyncio task (`handle_openai_response`) alive while
-   relaying user events. Always cancel it on disconnect to avoid leaked coroutines.
-
-## Environment & Secrets
-Create `backend/.env` with at least:
+## Environment
+Create `backend/.env` with:
 - `OPENAI_API_KEY` – required for realtime bridging.
-- `ALLOWED_ORIGINS` – optional CSV list to widen CORS beyond `http://localhost:3000`.
-- `OPENAI_REALTIME_MODEL`/`VOICE` – optional overrides for realtime sessions.
+- `ALLOWED_ORIGINS` – optional CSV to widen CORS.
+- `OPENAI_REALTIME_MODEL` / `OPENAI_REALTIME_VOICE` – optional overrides for session settings.
 
-Never commit `.env` files. `requirements.txt` lists additional security deps (slowapi,
-python-jose, passlib) that are not wired in yet—add usage deliberately.
-
-## Implementation Guidelines
-- Keep HTTP and WebSocket handlers **async**. Avoid blocking calls inside handlers; use
-  `asyncio` primitives when scheduling new tasks.
-- Mirror validation logic with the frontend (`/api/papers` route and `transformPapers`).
-  Schema changes must be updated in both services before deployment.
-- When modifying realtime flows, verify both the FastAPI WebSocket and the Next.js
-  WebRTC/SSE paths. The frontend still uses this legacy WS for fallback mode.
-- Maintain structured logging (`logger.info/error`). Do not log API keys or full OpenAI
-  responses.
-- If you add in-memory caches, make them IP-aware so they respect the rate limiter.
+`requirements.txt` also lists security-related packages (`slowapi`, `python-jose`,
+`passlib`) that are not currently in use—only pull them in deliberately.
 
 ## Testing Checklist
-- `uvicorn main:app --reload --host 0.0.0.0 --port 8000`
-- `curl http://localhost:8000/health`
-- `curl -X POST http://localhost:8000/api/papers -H 'Content-Type: application/json' -d '{"topics":["cs.AI"]}'`
-- Exercise `/ws/conversation` using the frontend fallback (`useRealtimeConversation`) or a
-  custom WebSocket client. Confirm audio/text events round-trip and rate limiting enforces
-  429/1008 responses under load.
+1. Start the server: `uvicorn main:app --host 0.0.0.0 --port 8000 --reload`.
+2. `curl http://localhost:8000/health` to confirm health.
+3. `curl -X POST http://localhost:8000/api/papers -H 'Content-Type: application/json' -d '{"topics":["cs.AI"]}'` to verify
+   arXiv integration.
+4. Exercise `/ws/conversation` using the frontend fallback or a custom WebSocket client. Ensure
+   audio/text messages flow and the rate limiter returns 429/1008 when the per-minute quota is
+   exceeded.

--- a/podcast-studio/src/app/api/papers/AGENT.md
+++ b/podcast-studio/src/app/api/papers/AGENT.md
@@ -1,40 +1,35 @@
 # `/api/papers` Route – Agent Guide
 
 ## Responsibility
-This App Router API route proxies Research Hub requests to the FastAPI backend. It enforces
-input validation identical to the backend, forwards the payload, and normalizes error
-responses so the client surfaces meaningful messages.
-
-```
-src/app/api/papers/route.ts
-```
+`src/app/api/papers/route.ts` is a Node runtime handler that proxies Research Hub requests to the
+FastAPI backend. It mirrors backend validation, forwards the payload, and normalises error
+responses so the UI can display clear messaging.
 
 ## Request Lifecycle
-1. Parse the JSON body and ensure `topics` exists, is an array of ≤10 strings, and each value
-   matches `^[a-zA-Z0-9.\-_]+$` with a ≤50 character limit. Keep this logic in sync with
-   `backend/main.py::PaperRequest` + `sanitize_input`.
-2. Forward the sanitized payload to `${BACKEND_URL}/api/papers`. `BACKEND_URL` defaults to
-   `http://localhost:8000`; override via `.env.local` when the backend lives elsewhere.
-3. On non-200 responses, attempt to parse `detail` from the backend error JSON and rethrow it
-   with the same status code. This allows the Research Hub to display specific validation or
-   rate-limit messages.
-4. Catch network failures (`ECONNREFUSED`) and respond with HTTP 503 instructing developers to
+1. Parse the JSON body from `NextRequest` and ensure `topics` exists, is an array with 1–10 string
+   entries, each ≤50 characters and matching `^[a-zA-Z0-9.\-_]+$`.
+2. Forward the payload to `${BACKEND_URL}/api/papers` (defaults to
+   `http://localhost:8000/api/papers`). No caching headers are set here because the client request
+   already uses `cache: "no-store"`.
+3. On non-200 responses, attempt to parse `{detail}` from the backend JSON and rethrow it as
+   `{ error }` with the original status so the Research Hub can surface validation or rate-limit
+   messages.
+4. Catch connection failures (e.g., `ECONNREFUSED`) and return HTTP 503 instructing developers to
    start the FastAPI server.
-5. Handle preflight requests via the `OPTIONS` export. CORS defaults to `http://localhost:3000`
-   but can be changed with `FRONTEND_URL` in the env.
+5. Respond to preflight requests via the exported `OPTIONS` handler, honouring `FRONTEND_URL`
+   (defaults to `http://localhost:3000`).
 
-## Implementation Guidelines
-- The route currently runs in the default Node.js runtime. If you introduce Node-only APIs,
-  add `export const runtime = "nodejs";` explicitly so Next.js does not attempt to execute it
-  on the edge.
-- Use `cache: 'no-store'` in the frontend fetch call instead of inside this route (the page
-  already sets it). Avoid introducing shared module-level state; App Router may reuse module
-  instances between requests.
-- If you add new backend query parameters, expose them here explicitly (either in the body or
-  query string) and update validation tests.
+## Implementation Notes
+- The route implicitly runs on the Node.js runtime—avoid importing client modules or using
+  edge-only APIs. If you introduce Node-specific APIs, you can add `export const runtime = "nodejs";`
+  explicitly.
+- Keep validation in sync with `backend/main.py::PaperRequest` and `sanitize_input`. Update both
+  sides when new constraints or fields are introduced.
+- Avoid storing module-level state. App Router may reuse the module across requests, so rely on
+  per-request variables.
 
 ## Testing
-- With the backend running: `curl -X POST http://localhost:3000/api/papers -H 'Content-Type:
-  application/json' -d '{"topics":["cs.AI"]}'`.
-- Simulate rate limiting or validation failures by sending too many topics; verify the status
-  code and error message bubble up to the UI.
+- With the backend running: `curl -X POST http://localhost:3000/api/papers -H 'Content-Type: application/json' -d '{"topics":["cs.AI"]}'`.
+- Simulate validation failures (e.g., too many topics) and verify the Research Hub displays the
+  returned error message.
+- Stop the backend to confirm the handler responds with HTTP 503 and helpful guidance.

--- a/podcast-studio/src/app/studio/AGENT.md
+++ b/podcast-studio/src/app/studio/AGENT.md
@@ -1,95 +1,88 @@
 # Audio Studio Agent Guide
 
 ## Purpose
-`src/app/studio/page.tsx` renders the realtime production workspace. It restores the paper
-selected on the Research Hub, manages OpenAI realtime sessions (WebRTC + HTTP fallbacks), and
-paints the multi-panel UI (transcript, controls, status sidebar).
+`src/app/studio/page.tsx` renders the realtime production workspace. It restores the paper selected
+on the Research Hub, manages OpenAI realtime sessions (WebRTC + HTTP fallbacks), streams
+microphone audio, displays transcripts, and exposes export/handoff tooling for downstream pages.
+The component is a client component rendered under `SidebarProvider` and `ApiConfigProvider`.
 
-The component is a client component that expects to run under the `SidebarProvider` and
-`ApiConfigProvider` wrappers declared in `src/app/layout.tsx`.
+## Layout & Context
+- Uses `Sidebar` and `Header` from the shared layout. Passes `isLiveRecording` to `Sidebar` so the
+  LIVE badge mirrors the recording state.
+- Reads provider/API key settings from `useApiConfig()`. `ensureRealtimeSession` merges those values
+  with `.env.local` fallbacks before calling `/api/rt/start`.
+- Restores the selected paper from `sessionStorage` (`vps:selectedPaper`) on mount and listens for
+  `storage` events so multi-tab selections stay in sync.
 
-## Anatomy
-- **Layout chrome** – `Sidebar` and `Header` render navigation and status. Pass
-  `isLiveRecording` to `Sidebar` so the "LIVE" badge tracks the recording state.
-- **Paper context** – Handoff uses `sessionStorage` key `vps:selectedPaper`. Malformed payloads
-  populate `paperLoadError` and surface a prompt to revisit the Research Hub.
-- **Workspace settings** – `useApiConfig()` pulls the active provider + API keys from the
-  Settings sheet (Sheet component). `ensureRealtimeSession` relies on this context before
-  contacting the server.
-- **Realtime state** – Flags for connection (`isConnected`, `isSessionReady`), recording
-  (`isRecording`, `isConnecting`), and timers (`sessionDuration`). `messages` holds the curated
-  transcript history rendered in the scroll area.
-- **Refs** – Extensive refs manage audio streaming:
-  - `pcRef`/`dcRef`/`aiTrackRef` – WebRTC peer connection, data channel, and remote audio track
-    (for playback).
-  - `audioContextRef`, `mediaRecorderRef`, `micChunkQueueRef`, `micFlushIntervalRef`,
-    `isUploadingRef` – control microphone capture, PCM16 encoding, and batching flushes to
-    `/api/rt/audio-append`.
-  - `aiTextBufferRef`, `aiTypingIntervalRef`, `lastAiMessageIdRef` – animate AI text output.
-  - `transcriptEndRef` – ensures auto-scroll as messages update.
+## State & Refs Highlights
+- Connection flags (`isConnecting`, `isConnected`, `isSessionReady`), recording flags
+  (`isRecording`, `isAudioPlaying`), timers (`sessionDuration`), and messaging state (`messages`,
+  `activeAiMessageId`, `statusMessage`, `error`).
+- WebRTC refs: `pcRef`, `dcRef`, `aiTrackRef` handle the peer connection, data channel, and remote
+  audio track.
+- Audio pipeline refs: `audioContextRef`, `mediaRecorderRef`, `micChunkQueueRef`,
+  `micFlushIntervalRef`, `isUploadingRef` manage PCM16 encoding and batching to the API routes.
+- Transcript rendering uses `aiTextBufferRef`, `aiTypingIntervalRef`, and `transcriptEndRef` to
+  animate streaming text and maintain auto-scroll.
 
-## Research Hub Handoff
-- On mount, read `sessionStorage.getItem('vps:selectedPaper')`. Store the parsed object in
-  `currentPaper` and log parse errors (the UI shows a recovery message).
-- Listen for `storage` events to support multi-tab workflows. If the user selects a new paper
-  in another tab, this page immediately updates.
-- Keep the stored schema (`SelectedPaper`) aligned with the writer in `src/app/page.tsx`.
-  Added fields should degrade gracefully when missing.
-
-## Provider & Session Management
-- `ensureRealtimeSession` validates that the active provider is `openai` (the Google branch is
-  not implemented yet) and that a usable API key exists. It then POSTs to `/api/rt/start` with
-  `{sessionId, provider, apiKey, model}` allowing the server to bootstrap the
-  `rtSessionManager` singleton.
-- Session status polling is available via `/api/rt/status`; use it during debugging to verify
-  the manager is active before sending audio.
-- `handleDisconnect` and `teardownRealtime` must always stop microphone capture, clear timers,
-  close the peer connection/data channel, and notify `/api/rt/stop` to release the session.
-
-## Connection Workflow
+## Session Management Workflow
 1. **Connect (`handleConnect`)**
-   - Calls `ensureRealtimeSession` (server boots session manager).
-   - Creates a `RTCPeerConnection`, attaches microphone track, negotiates with
-     `/api/rt/webrtc` (OpenAI SDP exchange), and opens a data channel (`oai-events`).
-   - Once the data channel is ready, send a session settings payload to request audio + text
-     modalities, voice, and VAD.
-2. **Recording (`handleStartRecording` / `startMicrophoneRecording`)**
-   - Requests microphone permission, creates a 24kHz `AudioContext`, and wires a ScriptProcessor
-     that converts Float32 PCM to PCM16.
-   - Queue PCM16 bytes in `micChunkQueueRef`; a 50 ms interval flush posts batched base64 to
-     `/api/rt/audio-append`. Guard against concurrent uploads using `isUploadingRef`.
-   - Call `/api/rt/audio-commit` after each flush to let OpenAI know the turn is complete.
-3. **Text messages (`handleSendText`)**
-   - POST to `/api/rt/text` after ensuring the session is active. Input is trimmed and cleared
-     once the request resolves.
-4. **Server events (`handleDcMessage`)**
-   - Data-channel messages include AI response deltas, transcription updates, and errors. Parse
-     cautiously and always guard unknown payloads with `try/catch`.
-   - SSE listeners (see `useEffect` hooks near the bottom of the file) consume
-     `/api/rt/audio`, `/api/rt/transcripts`, and `/api/rt/user-transcripts`. Each stream must
-     be unsubscribed in `teardownRealtime` to avoid leaking connections.
-5. **Disconnect (`handleStopRecording`, `handleDisconnect`, `teardownRealtime`)**
-   - Stop mic processing, clear buffers/intervals, pause audio playback, close peer/data
-     channels, and call `/api/rt/stop` to dispose of the server session.
+   - Calls `ensureRealtimeSession` to POST `/api/rt/start` with `{sessionId, provider, apiKey, model, paper}`.
+   - Creates an `RTCPeerConnection`, opens a data channel (`oai-events`), and attaches the
+     microphone track.
+   - Sends the SDP offer to `/api/rt/webrtc`; applies the returned answer and waits for the data
+     channel to open before sending initial session settings to OpenAI.
+   - Registers SSE listeners for `/api/rt/audio`, `/api/rt/transcripts`, and
+     `/api/rt/user-transcripts` via `startSseStream` helper effects.
+2. **Data channel handling (`handleDcMessage`)** – Parses JSON messages emitted by the server
+   (assistant messages, transcript updates, error notifications). Guard unknown payloads with
+   `try/catch` and log warnings instead of throwing.
+3. **Status polling** – `getSessionStatus` (used for debugging) hits `/api/rt/status` to inspect the
+   manager.
+4. **Disconnect (`handleDisconnect` / `teardownRealtime`)** – Stops microphone capture, clears
+   timers, closes the peer connection/data channel, detaches SSE streams, notifies `/api/rt/stop`,
+   and resets local state. A `useEffect` cleanup ensures teardown runs on unmount.
+
+## Microphone Pipeline
+- `handleStartRecording` requests microphone permission, initialises a 24 kHz `AudioContext`, and
+  pipes audio through a `ScriptProcessor` that converts Float32 buffers to PCM16 (`float32ToPcm16`).
+- PCM chunks are enqueued in `micChunkQueueRef`. A 50 ms interval flush posts batched base64 to
+  `/api/rt/audio-append`, guarded by `isUploadingRef` to prevent concurrent uploads.
+- After each flush, `/api/rt/audio-commit` signals the end of the turn so OpenAI produces a
+  response.
+- `handleStopRecording` stops the processor, clears intervals, commits any remaining audio, and
+  updates UI state.
+
+## Transcripts & Messages
+- Messages are stored as `{id, role, content, timestamp, type, speaker, order}`. Helper utilities
+  (`sortMessages`, `appendConversationMessage`, `updateAiMessage`) ensure deterministic ordering.
+- `useEffect` hooks subscribe to SSE streams, update `messages`, and maintain preview text for the
+  AI typing indicator.
+- Auto-scroll is handled by calling `transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth' })`
+  whenever transcripts update.
+
+## Conversation Storage & Exports
+- `buildConversationPayload` gathers the current conversation, merges AI/user audio recordings via
+  `encodePcm16ChunksToWav`, and returns a `StoredConversation` payload.
+- `handleDisconnect` and `handleSendToVideoStudio` persist this payload with
+  `saveConversationToSession`, enabling the Video Studio and Library to recover the session.
+- Export helpers:
+  - `handleExportTranscript` downloads a plain-text transcript.
+  - `handleDownloadAudio` builds a ZIP archive (via `createZipArchive`) containing AI/host WAV
+    tracks, transcript text, and metadata JSON.
 
 ## UI & Interaction Tips
-- Auto-scroll the transcript by calling `scrollIntoView` on `transcriptEndRef` whenever
-  `messages` or transcription preview changes.
-- Disable buttons when `isConnecting`, `isRecording`, or `isSessionReady` states do not allow a
-  given action to prevent accidental double submits.
-- Keep empty/error states empathetic. The current implementation shows helpful messaging when
-  there is no selected paper or when realtime setup fails.
-- `sessionDuration` drives the timer pill in the header; ensure it resets in teardown paths.
+- Disable controls appropriately: e.g., block multiple connect attempts, prevent recording when the
+  session is not ready, and show inline status messages for errors.
+- `statusMessage` surfaces non-blocking feedback; `error` displays blocking issues above the
+  controls. Keep copy user-friendly.
+- Reset timers and preview buffers when tearing down sessions to avoid stale data.
 
 ## Testing Checklist
-- Run `npm run lint` from the repository root (known upstream issues may still exist; document
-  them in PRs).
-- Manual:
-  - Start the backend + frontend, select a paper, and confirm it appears in the "Current Paper"
-    card.
-  - Connect to the realtime session, speak into the mic, and verify audio plays back plus
-    transcript/typing updates stream in.
-  - Toggle Settings → Workspace to swap API keys/providers; confirm guardrails block non-OpenAI
-    providers.
-  - Disconnect and ensure timers/audio contexts stop, SSE streams close, and the sidebar LIVE
-    badge clears.
+- With backend + realtime APIs configured, select a paper in the Research Hub and confirm the
+  “Current Paper” card populates.
+- Connect, record audio, observe transcript/audio SSE streams, and ensure the remote audio plays.
+- Use “Send to Video Studio” then open `/video-studio` to verify the conversation payload loads.
+- Download the audio bundle and confirm the ZIP contains WAV tracks, transcript, and metadata.
+- Exercise disconnect flows (stop while recording, refresh page) to ensure cleanup paths run without
+  throwing.

--- a/podcast-studio/src/components/layout/AGENT.md
+++ b/podcast-studio/src/components/layout/AGENT.md
@@ -1,59 +1,59 @@
 # Layout Components – Agent Guide
 
-The files in this directory compose the global chrome for every page: sidebar navigation,
-header, and workspace/user menus. They are client components that assume the `SidebarProvider`
-and `ApiConfigProvider` contexts are available (via `src/app/layout.tsx`).
+The components in this directory provide the global chrome rendered on every page: sidebar
+navigation, header, and the workspace/user menu. They are client components that assume the
+`SidebarProvider` and `ApiConfigProvider` wrappers from `src/app/layout.tsx` are present.
 
 ```
 src/components/layout/
-├── sidebar.tsx   # Navigation + collapse controls
-├── header.tsx    # Page title, status badges, search, actions
-├── user-menu.tsx # Avatar dropdown + workspace settings sheet
-└── AGENT.md      # This guide
+├── sidebar.tsx    # Navigation, collapse controls, LIVE badge
+├── header.tsx     # Page title, status chips, timer, search, actions
+├── user-menu.tsx  # Avatar dropdown + workspace settings sheet
+└── AGENT.md       # This guide
 ```
 
 ## Sidebar (`sidebar.tsx`)
-- Reads `useSidebar()` to toggle the collapsed state and highlights the active route via
-  `usePathname()`.
-- Accepts `isLiveRecording` to control the "LIVE" badge for the Audio Studio. Pass this prop
-  from pages that manage realtime sessions to keep UX consistent.
-- Navigation items are hard-coded (Research Hub, Audio Studio, Video Studio, Publisher, Library).
-  When modifying, update both the icon and descriptive copy. Keep badges short; they render in a
-  pill with Tailwind classes derived from `getBadgeColor`.
+- Reads `useSidebar()` to show the current collapse state and toggles via the menu button.
+- Navigation is defined inline (`Research Hub`, `Audio Studio`, `Video Studio`, `Publisher`,
+  `Episode Library`, `Analytics`). Update both `name`/`description`/`icon` when changing items.
+- Accepts `isLiveRecording`; when true, the “LIVE” badge remains visible for the Audio Studio entry.
+- Collapsed mode reduces the sidebar to icons only—ensure new items include tooltip-friendly
+  `name` values.
+- `getBadgeColor` maps badge labels to Tailwind classes. Add new cases there if you introduce more
+  badges.
 
 ## Header (`header.tsx`)
-- Displays the page title/description plus optional `status`, `timer`, `progress`, `actions`, and
+- Displays `title`/`description` alongside optional `status`, `timer`, `progress`, `actions`, and
   `search` props.
-- `status` expects `{label, color, active}`. Colors map to Tailwind classes in helper functions;
-  add new colors there if needed.
-- `search.onSearch` currently just logs input. If you wire it up, debounce in the page component
-  so the header stays stateless.
-- Always render `<UserMenu />` as the last item so workspace settings are accessible on every
-  page.
+- `status` expects `{label, color, active}` where color is one of `green`, `red`, `yellow`, `blue`,
+  `gray`. Helpers convert these into pulse dots and text colours.
+- `timer` renders a formatted duration with a clock icon. Pass a formatter that handles seconds.
+- `progress` shows a horizontal progress bar and optional label.
+- `search` renders an inline input with an icon and calls `onSearch` on change; debounce upstream if
+  you wire it to network requests.
+- Always render `<UserMenu />` as the trailing element so workspace settings remain accessible.
 
 ## User Menu (`user-menu.tsx`)
-- Combines Radix `DropdownMenu` and `Sheet` primitives to show profile settings and workspace
-  configuration.
-- Uses `useApiConfig()` to read/write API provider selections and keys. Persisted values are
-  trimmed before saving back to context/localStorage.
-- Profile/workspace UI uses local component state with optimistic logging (`console.info`). If
-  you integrate a backend, replace the logs with API calls but keep the separation between profile
-  and workspace sections.
-- The workspace sheet exposes checkboxes for preferences and forms for API keys. Maintain the
-  base field class (`baseFieldClass`) for consistent styling when adding new inputs.
+- Combines Radix DropdownMenu and Sheet primitives. Clicking menu items opens the sheet with either
+  profile or workspace settings.
+- Reads and writes API configuration via `useApiConfig()`, trimming keys before persisting them with
+  `setApiKey`. Keys remain in-memory only.
+- Maintains local `workspacePreferences` state (theme, autosave, analytics flags). Currently these
+  are logged in `handleSave`—replace logging with real API calls if backend persistence is added.
+- Generates user initials from the display name for the avatar badge.
+- The workspace sheet exposes checkboxes and text inputs styled with `baseFieldClass`. Reuse this
+  class when adding new form controls for consistent spacing.
 
 ## Implementation Tips
-- All components assume they are rendered as part of a responsive flex layout (see
-  `src/app/page.tsx`). When adding new sections, ensure collapsed sidebar width (`w-16`) still
-  accommodates icons without overflowing.
-- Use icons from `lucide-react` and keep them sized with Tailwind `w-4 h-4`/`w-5 h-5` utilities
-  to align with current spacing.
-- Prefer `Button` variants defined in `src/components/ui/button.tsx` when adding actions—this
-  keeps gradient/glass styling consistent.
+- Layout components expect to be rendered within a flex container (`Sidebar` + main content). Ensure
+  new wrappers preserve the flex structure so collapse animations remain smooth.
+- Use icons from `lucide-react` sized with Tailwind (`w-4 h-4`, `w-5 h-5`) to match existing spacing.
+- Keep focus/ARIA attributes intact (e.g., `aria-label` on the collapse button, keyboard navigation
+  for the dropdown and sheet).
 
 ## Testing
-- Toggle the sidebar collapse/expand button at multiple viewport widths.
-- Open the user menu, switch providers/keys, close the sheet, and reload the page to ensure
-  settings persist and UI state resets.
-- Validate keyboard navigation: tab through header controls, open the dropdown with Enter/Space,
-  and ensure focus returns to the trigger on close.
+- Toggle the sidebar at various viewport widths to confirm collapse animations and tooltips behave.
+- Open the user menu, adjust provider/API keys, close the sheet, refresh, and ensure provider
+  selections persist via context/localStorage.
+- Tab through header controls to verify keyboard focus order and that focus returns to the trigger
+  when the sheet closes.

--- a/podcast-studio/src/components/ui/AGENT.md
+++ b/podcast-studio/src/components/ui/AGENT.md
@@ -1,73 +1,64 @@
 # UI Components Agent Guide
 
 ## Purpose
-Reusable UI primitives built on top of shadcn/ui (Radix UI + Tailwind) live in this folder.
-They provide consistent theming for the Research Hub, Studio, and post-production pages.
-Each component exports semantic props and uses the shared `cn` helper from
-`src/lib/utils.ts`.
+Reusable shadcn-inspired primitives live in this directory. They wrap Radix UI components with the
+Tailwind design tokens defined in `src/app/globals.css` and expose props consumed throughout the
+Research Hub, Audio Studio, and post-production dashboards. All components re-export the shared
+`cn()` helper from `@/lib/utils` to compose classes safely.
 
 ```
 src/components/ui/
-├── button.tsx        # cva-powered gradient buttons
+├── button.tsx        # cva-powered gradient/outline/button variants
 ├── card.tsx          # Glass/gradient cards with header/content slots
-├── checkbox.tsx      # Radix checkbox, Tailwind focus styles
-├── dropdown-menu.tsx # Workspace menu, keyboard friendly
-├── scroll-area.tsx   # Styled viewport + scrollbar
-├── sheet.tsx         # Settings drawer (Radix dialog)
-├── tabs.tsx          # Timeline/analytics tab strip
+├── checkbox.tsx      # Radix checkbox with custom focus rings
+├── dropdown-menu.tsx # Workspace menu primitives
+├── scroll-area.tsx   # Styled scrollbars + viewport wrapper
+├── sheet.tsx         # Sliding drawer built on Radix dialog
+├── tabs.tsx          # Accessible tab list and content panels
 └── AGENT.md          # This guide
 ```
 
 ## Component Notes
-- **Button** (`button.tsx`)
-  - Uses `class-variance-authority` to expose `variant` (`default`, `gradient`, `glass`,
-    `outline`, etc.) and `size` props. Extend variants here before referencing them in pages.
-  - `asChild` lets you wrap anchors (`<Button asChild><a/></Button>`), preserving focus
-    styles.
-- **Card** (`card.tsx`)
-  - Layout-friendly slots (`CardHeader`, `CardContent`, `CardFooter`, etc.) with subtle
-    borders and backdrop blur. Keep padding consistent—Research Hub and Studio rely on the
-    default spacing.
-- **Checkbox** (`checkbox.tsx`)
-  - Wraps `@radix-ui/react-checkbox` with Tailwind focus rings. Only accepts boolean `checked`
-    and `onCheckedChange` from Radix. Keep icons sized with `size-3.5` to align with topic
-    toggles.
-- **DropdownMenu** (`dropdown-menu.tsx`)
-  - Provides menu items, separators, shortcuts, checkbox/radio items, and submenus. Each item
-    forwards the `data-variant` attribute (default/destructive). Update this file if you need
-    new menu surface styles rather than inlining overrides.
-- **ScrollArea** (`scroll-area.tsx`)
-  - Combines `ScrollArea.Root`, `.Viewport`, and `.Scrollbar` with custom thumb styling.
-    Reuse for scrollable panels instead of raw `<div>` overflow to keep consistent
-    scrollbar/keep-alive behaviour.
-- **Sheet** (`sheet.tsx`)
-  - Radix dialog configured as a sliding drawer (right/left/top/bottom). The Settings sheet
-    depends on the `side="right"` animation classes—keep transitions intact when editing.
-- **Tabs** (`tabs.tsx`)
-  - Inline-flex tab list with active-state border and focus rings. Used heavily by the Video
-    Studio; maintain the root/list/trigger/content structure so keyboard navigation works.
+- **Button (`button.tsx`)** – Uses `class-variance-authority` to provide `variant` (`default`,
+  `gradient`, `glass`, `outline`, `secondary`, `ghost`, `link`, `destructive`) and `size`
+  (`xs`, `sm`, `default`, `lg`, `icon`) options. Supports `asChild` for anchor-wrapped buttons and
+  applies consistent focus rings (`focus-visible:ring-*`).
+- **Card (`card.tsx`)** – Provides `Card`, `CardHeader`, `CardTitle`, `CardContent`, etc. with glass
+  backgrounds and subtle borders. Padding matches layout expectations; adjust tokens in
+  `globals.css` if new spacing is required.
+- **Checkbox (`checkbox.tsx`)** – Wraps `@radix-ui/react-checkbox` with rounded outlines and uses
+  `lucide-react` icons sized to `size-3.5`. Exposes controlled props compatible with Radix.
+- **Dropdown Menu (`dropdown-menu.tsx`)** – Re-exports Radix primitives with Tailwind styling,
+  including support for checkbox/radio items and `data-variant="destructive"` states. Used by the
+  user menu and workspace settings.
+- **Scroll Area (`scroll-area.tsx`)** – Combines `ScrollArea.Root`, `.Viewport`, `.Scrollbar`, and
+  `.Thumb` with gradient track styling. Prefer it over raw `overflow-y-auto` when you need
+  consistent scrollbars.
+- **Sheet (`sheet.tsx`)** – Implements a sliding drawer using `@radix-ui/react-dialog`. Supports
+  `side` (`top`, `bottom`, `left`, `right`) and provides header/footer helpers. The Settings sheet
+  relies on the right-side animation classes—update them centrally if you need new transitions.
+- **Tabs (`tabs.tsx`)** – Wraps `@radix-ui/react-tabs` with keyboard-accessible triggers and focus
+  outlines. Maintain the exported `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent` structure so
+  assistive technology works as expected.
 
 ## Styling Conventions
-- All components rely on the design tokens defined in `globals.css` (`gradient-primary`,
-  `glass`, `shadow-*`). If you introduce a new visual treatment, add utility classes there
-  rather than hard-coding hex values.
-- Focus states come from Tailwind (`focus-visible:ring-[3px]` etc.). Keep them accessible and
-  ensure `data-slot` attributes remain so design tooling can target them.
-- When adding new components, prefer `@radix-ui` primitives to maintain accessibility. Follow
-  the patterns above: wrap the primitive, apply Tailwind classes, and export named helpers.
+- Use gradient/glass tokens defined in `globals.css` (e.g., `gradient-primary`, `glass`,
+  `shadow-glow`). If you need new visual treatments, add utility classes there instead of hard-
+  coding colours.
+- Focus states rely on Tailwind’s `focus-visible` utilities; keep them present for accessibility.
+- Components set `data-slot` attributes where necessary (e.g., `<Button>`). Preserve them if you
+  extend the markup so design tooling keeps targeting hooks.
 
 ## Usage Tips
-- Import components via aliases (`@/components/ui/button`). The Next.js `tsconfig` path
-  handles alias resolution.
-- Compose shadcn components using the exported slots: e.g., `Card` + `CardHeader` +
-  `CardContent`. Avoid creating ad-hoc wrappers in page files; extend the primitive if the
-  pattern is shared.
-- Keep props typed – extend `React.ComponentProps<typeof Primitive>` when adding options so
-  TypeScript infers the correct attributes.
+- Import via path aliases (`@/components/ui/button`). TypeScript types are derived from the Radix
+  primitives, so extend props using `React.ComponentProps<typeof Primitive>` patterns.
+- Compose cards/buttons/etc. using their exported slots rather than duplicating markup in page
+  components. If you need repeated patterns, extend the primitive instead of forking it.
+- Keep new components client-safe unless they must run on the server. All current files are client
+  components (`"use client"`) because they depend on Radix.
 
 ## Testing
-- Visual regressions: run the Next.js dev server (`npm run dev`) and inspect focus/hover
-  states in dark/light modes.
-- Accessibility: validate keyboard navigation for DropdownMenu, Sheet, and Tabs when altering
-  markup. Radix handles most ARIA attributes; avoid removing structural wrappers that provide
-  them.
+- Visual inspection: run `npm run dev` and verify hover/focus/disabled states in dark and light
+  backgrounds.
+- Accessibility: tab through DropdownMenu, Sheet, and Tabs to ensure keyboard controls and focus
+  management remain intact after changes.

--- a/podcast-studio/src/contexts/AGENT.md
+++ b/podcast-studio/src/contexts/AGENT.md
@@ -1,51 +1,46 @@
 # Context Providers – Agent Guide
 
-Two React contexts live in this directory. Both are client components and are composed in
-`src/app/layout.tsx` so every page shares the same state.
+Two client-side React contexts live in this directory. Both are wired up in `src/app/layout.tsx` so
+that every page shares the same state tree.
 
 ```
 src/contexts/
-├── sidebar-context.tsx   # Collapse state for layout chrome
-├── api-config-context.tsx # Persisted API provider + keys
+├── sidebar-context.tsx    # Layout collapse state
+├── api-config-context.tsx # Provider selection + API keys/models
 └── AGENT.md               # This guide
 ```
 
-## Sidebar Context
-- `SidebarProvider` stores a simple boolean `collapsed` state with `toggleCollapsed` and
-  `setCollapsed` helpers.
-- Any component calling `useSidebar()` must be rendered within the provider. The layout wrapper
-  already does this, but unit tests or Storybook entries should wrap components explicitly.
-- When adding new sidebar UI affordances (e.g., multi-column layouts), extend the context shape
-  cautiously. Keep backwards compatibility in mind because many components destructure
-  `collapsed` and `toggleCollapsed` directly.
+## Sidebar Context (`sidebar-context.tsx`)
+- `SidebarProvider` stores a boolean `collapsed` flag and exposes `toggleCollapsed` plus
+  `setCollapsed`. The default is expanded (`false`).
+- `useSidebar()` throws if accessed outside the provider—wrap standalone stories/tests accordingly.
+- When adding new layout affordances (e.g., remembering collapse state per route), extend the context
+  shape carefully. Many consumers destructure `{ collapsed, toggleCollapsed }` directly.
 
-## API Config Context
-- `ApiConfigProvider` persists the user's chosen LLM provider (`openai` or `google`) and optional
-  model overrides to `localStorage` under `vps:llmConfig`. API keys are kept in-memory only so they
-  are never written to persistent browser storage.
+## API Config Context (`api-config-context.tsx`)
+- `ApiConfigProvider` persists provider preferences and optional model overrides to localStorage
+  under `vps:llmConfig`. API keys are stored in component state only (never persisted) for security.
 - Hydration flow:
-  1. On mount, attempt to read and parse the stored JSON.
-  2. `hasHydrated` guards against writing back until the initial read completes.
-  3. Any provider/model mutation re-serializes to `localStorage`; key updates stay in volatile state
-     for security.
-- Consumers (`useApiConfig`) receive `{ activeProvider, apiKeys, models, setActiveProvider,
-  setApiKey, clearApiKey, setModel }`.
-- The Audio Studio relies on this context to gate `/api/rt/start` calls. Maintain the guard that
-  falls back to the environment `OPENAI_API_KEY` only on the server—client components should
-  always respect the user-specified keys provided during the current session.
+  1. On mount, read localStorage and normalise the provider (`openai` default, `google` supported for
+     future use).
+  2. `hasHydrated` prevents writes until the initial read completes.
+  3. `setActiveProvider`, `setModel` update `preferences` which are serialised back to localStorage.
+  4. `setApiKey` stores volatile keys in memory; `clearApiKey` simply blanks them.
+- `useApiConfig()` exposes `{ activeProvider, apiKeys, models, setActiveProvider, setApiKey,
+  clearApiKey, setModel }`. The Audio Studio reads this context before bootstrapping sessions.
+- Keep the stored shape backwards compatible. If you add fields, extend `defaultPreferences` and use
+  optional chaining when reading from parsed objects.
 
 ## Implementation Tips
-- Keep both providers client components (they access browser storage). Mark new providers with
-  `"use client"` and wrap them in `layout.tsx` so Server Components can still render children.
-- When extending the stored data shape, bump `defaultState` with sensible defaults and ensure
-  migration logic handles older payloads gracefully (e.g., optional chaining when reading
-  `parsed.apiKeys`).
-- Avoid writing to `localStorage` during SSR. The current guard (`hasHydrated`) prevents this;
-  preserve that pattern if you refactor.
+- Both providers are client components (`"use client"`). Do not move them to the server; they access
+  browser-only APIs like `localStorage`.
+- Wrap new top-level providers in `src/app/layout.tsx` so server components can still render
+  children.
+- Avoid writing to `localStorage` during SSR. The existing hydration guard covers this—preserve the
+  pattern when refactoring.
 
 ## Testing
-- Manual: open the Settings sheet, swap providers, add/remove API keys, refresh the page, and
-  confirm the selections persist.
-- Automated: consider writing React Testing Library tests that render consumers under the
-  provider and exercise `setApiKey`/`clearApiKey` to ensure serialization does not throw in
-  `jsdom`.
+- Manual: open the workspace settings sheet, change providers, set/clear API keys, refresh the page,
+  and confirm the provider/model selection persists while keys reset (as designed).
+- Automated: when adding logic, write React Testing Library tests that render consumers under the
+  providers and exercise setter functions to ensure they do not throw in `jsdom` environments.

--- a/podcast-studio/src/lib/AGENT.md
+++ b/podcast-studio/src/lib/AGENT.md
@@ -1,64 +1,66 @@
 # Library Modules – Agent Guide
 
-The `src/lib` directory contains utilities used by API routes and client components. The
-realtime session manager is the heart of the server-side realtime workflow; treat it with
-care.
+`src/lib` houses utilities shared across API routes and client components. Changes here typically
+impact multiple parts of the app—coordinate updates carefully.
 
 ```
 src/lib/
-├── realtimeSession.ts    # Node-side singleton talking to OpenAI Realtime
-├── conversationStorage.ts # Shared helpers for persisting conversations between pages
-├── utils.ts              # Tailwind-friendly `cn()` helper
-└── AGENT.md              # This guide
+├── realtimeSession.ts     # Node-side singleton that talks to OpenAI Realtime
+├── conversationStorage.ts # sessionStorage helpers + PCM16 <-> WAV utilities
+├── utils.ts               # Tailwind-friendly `cn()` helper
+└── AGENT.md               # This guide
 ```
 
 ## `realtimeSession.ts`
-- Exports a hot-reload-safe singleton (`rtSessionManager`) that stores `RTManager` instances by
-  `sessionId`. Each `RTManager` maintains a WebSocket connection to OpenAI and exposes helper
-  methods used by API routes (`start`, `appendPcm16`, `commitTurn`, `sendText`, `stop`).
-- Connection flow:
-  1. `start()` verifies an API key, fetches `/v1/models` as a sanity check, and opens the
-     realtime WebSocket.
-  2. `_setupWebSocketHandlers` sends a `session.update` payload configuring modalities, voice,
-     transcription, and server-side VAD. Modify this payload carefully—the Audio Studio assumes
-     text+audio modes are enabled.
-  3. Incoming events emit on the `EventEmitter` interface: `audio`, `transcript`,
-     `user_transcript`, `user_transcript_delta`, `assistant_done`, `close`, and `error`.
-     API routes under `src/app/api/rt` stream these events back to the browser via SSE.
-  4. `responseInFlight` prevents duplicate `response.create` calls. When you add new event types,
-     update `_handleEvent` to keep this guard accurate.
-- Session cleanup: `RTSessionManager.removeSession` calls `stop()` and clears timeouts. Idle
-  sessions auto-expire after 30 minutes. Always go through the manager (never instantiate
-  `RTManager` directly) so cleanup runs reliably.
-- Provider support: only `openai` is implemented. The Google branch throws a descriptive error.
-  If you implement another provider, update `configure`, `_establishConnection`, and the API
-  routes to accept provider-specific headers.
-
-## `utils.ts`
-- Simple `cn()` helper that merges class names using `clsx` + `tailwind-merge`. Use it everywhere
-  you compose Tailwind classes to avoid conflicting utilities.
+- Exposes a hot-reload-safe singleton (`rtSessionManager`) that stores `RTManager` instances by
+  `sessionId`. Each manager maintains an OpenAI realtime WebSocket connection and emits events the
+  API routes forward to the browser.
+- `configure()` normalises provider (`openai`/`google`), resolves API keys (preferring user-provided
+  keys, falling back to server env vars for OpenAI), stores optional model overrides, and sanitises
+  paper context fields (title, authors, abstract, etc.). When context changes while connected,
+  `_pushSessionUpdate` sends updated instructions to OpenAI.
+- `_doStart()` establishes the WebSocket connection with a 10 second timeout, sends an initial
+  `session.update` payload (text+audio modalities, Whisper transcription, server VAD), and emits a
+  `ready` event on success. Errors clear state and bubble up for the API route to surface.
+- Event handling: `_handleEvent` listens for OpenAI messages and emits on the internal
+  `EventEmitter` (`audio`, `transcript`, `user_transcript`, `user_transcript_delta`, `assistant_done`,
+  `ready`, `close`, `error`). SSE routes subscribe to these events.
+- Input helpers: `appendPcm16` queues audio frames, `commitTurn` triggers `response.create`, and
+  `sendText` submits text messages. `isActive()`/`isStarting()`/`getStatus()` report lifecycle state.
+- Session cleanup: `removeSession` stops the WebSocket, clears inactivity timers (30-minute idle
+  timeout), and removes the manager from the singleton. `cleanup()` tears down all sessions—useful in
+  tests.
 
 ## `conversationStorage.ts`
-- Centralises the sessionStorage contract used to hand conversation data from the Audio Studio
-  to the Video Studio.
-- Provides cross-runtime helpers to encode PCM16 chunks into WAV/base64 pairs and decode them
-  back into typed arrays for waveform rendering.
-- Exposes `saveConversationToSession`, `loadConversationFromSession`, and a shared
-  `StoredConversation` interface so both pages stay in sync. Guard browser-only APIs with
-  `typeof window !== 'undefined'` before calling them.
+- Defines the sessionStorage contract for saving/reloading the most recent conversation under
+  `vps:latestConversation`. Includes interfaces for stored papers, transcript entries, audio tracks,
+  and metadata.
+- `encodePcm16ChunksToWav` converts raw PCM16 byte chunks into a base64 WAV with duration metadata;
+  `decodeWavBase64` performs the inverse for the Video Studio waveform visualisation.
+- `saveConversationToSession`, `loadConversationFromSession`, `clearConversationFromSession` guard
+  against server usage by checking `typeof window !== 'undefined'`.
+- Utility helpers (`toBase64`, `fromBase64`) support both browser (`btoa`/`atob`) and Node
+  environments (using `Buffer`).
+
+## `utils.ts`
+- Currently exports `cn(...classes)` which combines `clsx` and `tailwind-merge`. Use this helper for
+  composing Tailwind class strings to avoid conflicting utilities.
 
 ## Implementation Guidelines
-- Keep `realtimeSession.ts` Node-compatible. App Router API routes import it with
-  `export const runtime = "nodejs";`. Avoid referencing browser APIs inside the module.
-- When using `conversationStorage.ts` in a server context, guard any storage helpers with the
-  `isBrowser` flag they expose so builds do not access `window` during SSR.
-- When adding new events to the emitter, document them in the `src/app/api/rt/AGENT.md` (see
-  below) and update any SSE consumers in the Audio Studio.
-- Logging uses `log.info/error/warn/debug`; keep logs concise and avoid printing raw audio buffers
-  or secrets.
+- Keep `realtimeSession.ts` Node-compatible—API routes import it with `runtime = "nodejs"`. Avoid
+  referencing browser APIs inside the module.
+- When adding new realtime events, update the `/api/rt/*` routes to subscribe/unsubscribe properly
+  and document the event name in the relevant AGENT files.
+- Treat the conversation storage schema as shared API. If you evolve the structure, migrate existing
+  stored payloads gracefully (`JSON.parse` should never throw) and update all consumers (Audio Studio,
+  Video Studio, Library, Publisher).
+- Logging helpers (`log.info`, `log.error`, etc.) already redact large payloads. Continue using them
+  for consistency.
 
 ## Testing
-- Start the Next.js dev server and hit `/api/rt/start`, `/api/rt/status`, `/api/rt/audio` etc.
-  while watching server logs to ensure events trigger as expected.
-- Use a standalone Node script to instantiate `rtSessionManager.getSession('test')` and exercise
-  `start()`/`sendText()` when experimenting with new provider settings.
+- Start the Next.js dev server and exercise `/api/rt/start`, `/api/rt/status`, `/api/rt/audio`, etc.,
+  watching the server logs produced by `realtimeSession.ts` for expected events.
+- Use a Node REPL or script to import `rtSessionManager`, create a session, and send text/audio when
+  experimenting with provider changes.
+- Validate `conversationStorage.ts` helpers in the browser console (saving/loading) and within the
+  Video Studio waveform rendering paths.


### PR DESCRIPTION
## Summary
- overhaul the root handbook and backend/frontend AGENT guides to reflect the current architecture and workflows
- refresh page- and feature-specific AGENTs (research hub, realtime API, audio studio, layout/ui, contexts, lib) with accurate state, lifecycle, and testing notes
- rewrite the README with updated setup instructions, architecture overview, realtime workflow walkthrough, and troubleshooting tips

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ccfeb465f4832e91e0606a286a4745