### PR TITLE
Refactor audio studio experience and harden realtime APIs

### DIFF
--- a/podcast-studio/src/app/api/rt/audio-append/route.ts
+++ b/podcast-studio/src/app/api/rt/audio-append/route.ts
@@ -41,15 +41,16 @@ export async function POST(req: Request) {
       message: 'Audio chunk appended successfully' 
     });
     
-  } catch (error: any) {
-    console.error(`[ERROR] Failed to append audio`, { 
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to append audio';
+    console.error(`[ERROR] Failed to append audio`, {
       sessionId,
-      error: error.message,
-      stack: error.stack 
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined
     });
-    
+
     let status = 500;
-    let errorMessage = error.message || 'Failed to append audio';
+    const errorMessage = message;
     
     if (errorMessage.includes('Session not ready')) {
       status = 503;

--- a/podcast-studio/src/app/api/rt/audio-commit/route.ts
+++ b/podcast-studio/src/app/api/rt/audio-commit/route.ts
@@ -36,15 +36,16 @@ export async function POST(req: Request) {
       message: 'Audio turn committed successfully' 
     });
     
-  } catch (error: any) {
-    console.error(`[ERROR] Failed to commit audio turn`, { 
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to commit audio turn';
+    console.error(`[ERROR] Failed to commit audio turn`, {
       sessionId,
-      error: error.message,
-      stack: error.stack 
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined
     });
-    
+
     let status = 500;
-    let errorMessage = error.message || 'Failed to commit audio turn';
+    const errorMessage = message;
     
     if (errorMessage.includes('Session not ready')) {
       status = 503;

--- a/podcast-studio/src/app/api/rt/audio/route.ts
+++ b/podcast-studio/src/app/api/rt/audio/route.ts
@@ -3,23 +3,6 @@ import { rtSessionManager } from "@/lib/realtimeSession";
 
 export const runtime = "nodejs";
 
-function wavHeader(sampleRate: number): Buffer {
-  const header = Buffer.alloc(44);
-  header.write("RIFF", 0); 
-  header.writeUInt32LE(0xffffffff, 4); // chunk size unknown (streaming)
-  header.write("WAVEfmt ", 8);
-  header.writeUInt32LE(16, 16); // PCM format chunk size
-  header.writeUInt16LE(1, 20); // PCM format
-  header.writeUInt16LE(1, 22); // mono
-  header.writeUInt32LE(sampleRate, 24); // sample rate
-  header.writeUInt32LE(sampleRate * 2, 28); // byte rate (sample rate * channels * bytes per sample)
-  header.writeUInt16LE(2, 32); // block align (channels * bytes per sample)
-  header.writeUInt16LE(16, 34); // bits per sample
-  header.write("data", 36); 
-  header.writeUInt32LE(0xffffffff, 40); // data chunk size unknown
-  return header;
-}
-
 export async function GET(req: Request) {
   let sessionId = 'default';
   
@@ -43,10 +26,12 @@ export async function GET(req: Request) {
       });
     }
     
-    const stream = new ReadableStream({
+    let cleanup: (() => void) | undefined;
+
+    const stream = new ReadableStream<string>({
       start(controller) {
         console.log(`[INFO] Audio stream started`, { sessionId });
-        
+
         const send = (audioData: Uint8Array) => {
           try {
             // Send audio as base64 in Server-Sent Events format
@@ -66,6 +51,7 @@ export async function GET(req: Request) {
         
         const onClose = () => {
           console.log(`[INFO] Session closed - ending audio stream`, { sessionId });
+          cleanup?.();
           try {
             controller.close();
           } catch (error) {
@@ -73,15 +59,16 @@ export async function GET(req: Request) {
           }
         };
         
-        const onError = (error: any) => {
-          console.error(`[ERROR] Session error in audio stream`, { sessionId, error });
+        const onError = (error: unknown) => {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          console.error(`[ERROR] Session error in audio stream`, { sessionId, error: message });
           try {
-            controller.enqueue(`event: error\ndata: ${error.message || 'Unknown error'}\n\n`);
+            controller.enqueue(`event: error\ndata: ${message}\n\n`);
           } catch (e) {
             console.error(`[ERROR] Failed to send error to audio stream`, { sessionId, e });
           }
         };
-        
+
         // Wire up event listeners
         manager.on("audio", onAudio);
         manager.once("close", onClose);
@@ -94,28 +81,27 @@ export async function GET(req: Request) {
         const interval = setInterval(() => {
           try {
             controller.enqueue(`: keep-alive\n\n`);
-          } catch (error) {
+          } catch {
             console.log(`[DEBUG] Keep-alive failed (stream likely closed)`, { sessionId });
             clearInterval(interval);
           }
         }, 15000);
-        
-        // Cleanup function
-        (controller as any)._cleanup = () => {
+
+        cleanup = () => {
           console.log(`[INFO] Cleaning up audio stream`, { sessionId });
           clearInterval(interval);
           manager.off("audio", onAudio);
           manager.off("error", onError);
         };
       },
-      cancel() { 
+      cancel() {
         console.log(`[INFO] Audio stream cancelled`, { sessionId });
-        (this as any)._cleanup?.(); 
+        cleanup?.();
       }
     });
-    
-    return new Response(stream, { 
-      headers: { 
+
+    return new Response(stream, {
+      headers: {
         "Content-Type": "text/event-stream", 
         "Cache-Control": "no-cache",
         "Connection": "keep-alive",
@@ -124,9 +110,10 @@ export async function GET(req: Request) {
       } 
     });
     
-  } catch (error: any) {
-    console.error(`[ERROR] Failed to create audio stream`, { sessionId, error: error.message });
-    return new Response(`event: error\ndata: ${error.message}\n\n`, {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to create audio stream';
+    console.error(`[ERROR] Failed to create audio stream`, { sessionId, error: message });
+    return new Response(`event: error\ndata: ${message}\n\n`, {
       status: 500,
       headers: { "Content-Type": "text/event-stream" }
     });

--- a/podcast-studio/src/app/api/rt/status/route.ts
+++ b/podcast-studio/src/app/api/rt/status/route.ts
@@ -34,14 +34,15 @@ export async function GET(req: Request) {
 
     return NextResponse.json(response);
     
-  } catch (error: any) {
-    console.error(`[ERROR] Status check failed`, { 
-      error: error.message,
-      stack: error.stack 
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to check status';
+    console.error(`[ERROR] Status check failed`, {
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined
     });
-    
-    return NextResponse.json({ 
-      error: error.message || 'Failed to check status' 
+
+    return NextResponse.json({
+      error: message
     }, { status: 500 });
   }
 }

--- a/podcast-studio/src/app/api/rt/stop/route.ts
+++ b/podcast-studio/src/app/api/rt/stop/route.ts
@@ -14,10 +14,11 @@ export async function POST(req: Request) {
       ok: true, 
       message: 'Realtime session stopped successfully' 
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to stop realtime session';
     console.error('Error stopping realtime session:', error);
-    return NextResponse.json({ 
-      error: error.message || 'Failed to stop realtime session' 
+    return NextResponse.json({
+      error: message
     }, { status: 500 });
   }
 }

--- a/podcast-studio/src/app/api/rt/text/route.ts
+++ b/podcast-studio/src/app/api/rt/text/route.ts
@@ -42,15 +42,16 @@ export async function POST(req: Request) {
       message: 'Text sent successfully' 
     });
     
-  } catch (error: any) {
-    console.error(`[ERROR] Failed to send text`, { 
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to send text';
+    console.error(`[ERROR] Failed to send text`, {
       sessionId,
-      error: error.message,
-      stack: error.stack 
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined
     });
-    
+
     let status = 500;
-    let errorMessage = error.message || 'Failed to send text';
+    const errorMessage = message;
     
     if (errorMessage.includes('Session not ready')) {
       status = 503;

--- a/podcast-studio/src/app/api/rt/webrtc/route.ts
+++ b/podcast-studio/src/app/api/rt/webrtc/route.ts
@@ -52,8 +52,9 @@ export async function POST(req: Request) {
     }
 
     return new NextResponse(answer, { status: 200, headers: { 'Content-Type': 'application/sdp' } });
-  } catch (error: any) {
-    return new NextResponse(JSON.stringify({ error: error.message || 'Failed to exchange SDP' }), { status: 500 });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to exchange SDP';
+    return new NextResponse(JSON.stringify({ error: message }), { status: 500 });
   }
 }
 

--- a/podcast-studio/src/app/api/test-openai/route.ts
+++ b/podcast-studio/src/app/api/test-openai/route.ts
@@ -40,26 +40,28 @@ export async function GET() {
       }, { status: 500 });
     }
     
-    const models = await response.json();
-    console.log('[TEST] Found', models.data?.length || 0, 'models');
-    
+    const models = await response.json() as { data?: Array<{ id: string }> };
+    const modelList = Array.isArray(models.data) ? models.data : [];
+    console.log('[TEST] Found', modelList.length, 'models');
+
     // Check if gpt-4o-realtime model is available
-    const realtimeModels = models.data?.filter((m: any) => m.id.includes('realtime')) || [];
-    console.log('[TEST] Realtime models found:', realtimeModels.map((m: any) => m.id));
+    const realtimeModels = modelList.filter((model) => typeof model.id === 'string' && model.id.includes('realtime'));
+    console.log('[TEST] Realtime models found:', realtimeModels.map((model) => model.id));
     
     return NextResponse.json({ 
       success: true,
       hasKey: true,
       keyLength: apiKey.length,
-      modelsCount: models.data?.length || 0,
-      realtimeModels: realtimeModels.map((m: any) => m.id)
+      modelsCount: modelList.length,
+      realtimeModels: realtimeModels.map((model) => model.id)
     });
-    
-  } catch (error: any) {
+
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to reach OpenAI';
     console.error('[TEST] Error testing OpenAI connection:', error);
-    return NextResponse.json({ 
-      error: error.message,
-      hasKey: !!process.env.OPENAI_API_KEY 
+    return NextResponse.json({
+      error: message,
+      hasKey: !!process.env.OPENAI_API_KEY
     }, { status: 500 });
   }
 }

--- a/podcast-studio/src/app/studio/page.tsx
+++ b/podcast-studio/src/app/studio/page.tsx
@@ -1,48 +1,37 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useRouter } from "next/navigation";
+import { Sidebar } from "@/components/layout/sidebar";
+import { Header } from "@/components/layout/header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Sidebar } from "@/components/layout/sidebar";
-import { Header } from "@/components/layout/header";
 import { useSidebar } from "@/contexts/sidebar-context";
 import { useApiConfig } from "@/contexts/api-config-context";
-import { useRouter } from "next/navigation";
 import {
   encodePcm16ChunksToWav,
   saveConversationToSession,
   type StoredConversation,
 } from "@/lib/conversationStorage";
 import {
-  Mic,
-  BookOpen,
   Brain,
-  Play,
+  Download,
   FileText,
   Headphones,
-  Download,
-  RotateCcw,
-  Volume2,
-  Send,
+  Mic,
   MicOff,
-  Pause,
+  Radio,
+  Sparkles,
   Video,
+  Volume2,
 } from "lucide-react";
-
-interface ConversationMessage {
-  id: string;
-  role: 'user' | 'expert';
-  content: string;
-  timestamp: Date;
-  type: 'text' | 'audio';
-  speaker?: string;
-  order: number;
-}
-
-type MicrophoneProcessor = {
-  stop: () => void;
-};
 
 interface SelectedPaper {
   id: string;
@@ -55,10 +44,24 @@ interface SelectedPaper {
   formattedPublishedDate?: string;
 }
 
+type Speaker = "host" | "ai";
+
+type ConnectionPhase = "idle" | "preparing" | "live" | "stopping";
+
+interface TranscriptEntry {
+  id: string;
+  speaker: Speaker;
+  text: string;
+  status: "streaming" | "final";
+  startedAt: number;
+  completedAt?: number;
+  updatedAt?: number;
+}
+
 const AI_BASE_INSTRUCTION_LINES = [
-  'You are Dr. Sarah, an AI scientist joining a podcast conversation.',
-  'Respond conversationally, stay grounded in the selected research, and avoid speculation.',
-  'Keep every reply under three concise sentences (about 75 tokens) to control cost.',
+  "You are Dr. Sarah, an AI scientist joining a podcast conversation.",
+  "Respond conversationally, stay grounded in the selected research, and avoid speculation.",
+  "Keep every reply under three concise sentences (about 75 tokens) to control cost.",
 ];
 
 const MAX_ABSTRACT_SNIPPET = 400;
@@ -67,7 +70,7 @@ const sanitizeInstructionText = (value?: string | null) => {
   if (!value) {
     return undefined;
   }
-  const trimmed = value.replace(/\s+/g, ' ').trim();
+  const trimmed = value.replace(/\s+/g, " ").trim();
   if (!trimmed) {
     return undefined;
   }
@@ -78,7 +81,7 @@ const sanitizeInstructionText = (value?: string | null) => {
 };
 
 const buildConversationInstructionsFromPaper = (paper: SelectedPaper | null): string => {
-  const base = AI_BASE_INSTRUCTION_LINES.join(' ');
+  const base = AI_BASE_INSTRUCTION_LINES.join(" ");
 
   if (!paper) {
     return base;
@@ -91,7 +94,7 @@ const buildConversationInstructionsFromPaper = (paper: SelectedPaper | null): st
   const arxivUrl = sanitizeInstructionText(paper.arxiv_url);
   const authorLine = sanitizeInstructionText(
     paper.primaryAuthor
-      ? `${paper.primaryAuthor}${paper.hasAdditionalAuthors ? ' et al.' : ''}`
+      ? `${paper.primaryAuthor}${paper.hasAdditionalAuthors ? " et al." : ""}`
       : paper.authors,
   );
 
@@ -113,17 +116,19 @@ const buildConversationInstructionsFromPaper = (paper: SelectedPaper | null): st
   }
 
   if (contextParts.length > 0) {
-    details.push(`Context: ${contextParts.join('; ')}`);
+    details.push(`Context: ${contextParts.join("; ")}`);
   }
 
-  details.push('Answer briefly, relate insights back to the paper, and avoid repeating this context verbatim.');
+  details.push(
+    "Answer briefly, relate insights back to the paper, and avoid repeating this context verbatim.",
+  );
 
-  return `${base} ${details.join(' ')}`.trim();
+  return `${base} ${details.join(" ")}`.trim();
 };
 
 const nextWordChunk = (text: string): [string, string] => {
   if (!text) {
-    return ['', ''];
+    return ["", ""];
   }
 
   const match = text.match(/^[^\s]+\s*/);
@@ -270,215 +275,60 @@ function createZipArchive(files: Array<{ name: string; data: Uint8Array }>): Uin
   return archive;
 }
 
-export default function Studio() {
+const formatTime = (seconds: number) => {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+};
+
+const StudioPage: React.FC = () => {
   const { collapsed, toggleCollapsed } = useSidebar();
   const { activeProvider, apiKeys } = useApiConfig();
   const activeApiKey = (apiKeys[activeProvider] ?? "").trim();
-  const providerLabel = activeProvider === "openai" ? "OpenAI" : "Google";
   const router = useRouter();
 
-  // State for the realtime studio
-  const [isConnected, setIsConnected] = useState(false);
-  const [isSessionReady, setIsSessionReady] = useState(false);
-  const [isRecording, setIsRecording] = useState(false);
-  const [messages, setMessages] = useState<ConversationMessage[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [isTranscribing, setIsTranscribing] = useState(false);
-  const [isUserSpeaking, setIsUserSpeaking] = useState(false);
-  const [userTranscriptionDisplay, setUserTranscriptionDisplay] = useState('');
-  const [textInput, setTextInput] = useState("");
-  const [sessionDuration, setSessionDuration] = useState(0);
-  const [isAudioPlaying, setIsAudioPlaying] = useState(false);
-  const [isConnecting, setIsConnecting] = useState(false);
   const [sessionId] = useState(() => `session_${Date.now()}`);
+  const [phase, setPhase] = useState<ConnectionPhase>("idle");
+  const [isRecording, setIsRecording] = useState(false);
+  const [isAudioPlaying, setIsAudioPlaying] = useState(false);
+  const [entries, setEntries] = useState<TranscriptEntry[]>([]);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionDuration, setSessionDuration] = useState(0);
   const [currentPaper, setCurrentPaper] = useState<SelectedPaper | null>(null);
   const [paperLoadError, setPaperLoadError] = useState<string | null>(null);
   const [hasCapturedAudio, setHasCapturedAudio] = useState(false);
-  const [activeAiMessageId, setActiveAiMessageId] = useState<string | null>(null);
-  const [activeUserMessageId, setActiveUserMessageId] = useState<string | null>(null);
+  const [isHostSpeaking, setIsHostSpeaking] = useState(false);
+  const [isAiSpeaking, setIsAiSpeaking] = useState(false);
 
-  // Refs for real-time functionality
-  const audioRef = useRef<HTMLAudioElement>(null);
-  const mediaRecorderRef = useRef<MicrophoneProcessor | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const micChunkQueueRef = useRef<Uint8Array[]>([]);
-  const micFlushIntervalRef = useRef<number | null>(null);
-  const isUploadingRef = useRef<boolean>(false);
-  const hostAudioChunksRef = useRef<Uint8Array[]>([]);
-  const aiAudioChunksRef = useRef<Uint8Array[]>([]);
-  const audioEventSourceRef = useRef<EventSource | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   const pcRef = useRef<RTCPeerConnection | null>(null);
   const dcRef = useRef<RTCDataChannel | null>(null);
-  const lastAiMessageIdRef = useRef<string | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const mediaRecorderRef = useRef<{ stop: () => void } | null>(null);
+  const micChunkQueueRef = useRef<Uint8Array[]>([]);
+  const micFlushIntervalRef = useRef<number | null>(null);
+  const isUploadingRef = useRef(false);
+  const isCommittingRef = useRef(false);
   const aiTrackRef = useRef<MediaStreamTrack | null>(null);
-  const aiAudioStartedRef = useRef<boolean>(false);
-  const aiTextBufferRef = useRef<string>("");
-  const aiTypingIntervalRef = useRef<number | null>(null);
-  const messageSequenceRef = useRef(0);
+  const aiAudioChunksRef = useRef<Uint8Array[]>([]);
+  const hostAudioChunksRef = useRef<Uint8Array[]>([]);
+  const audioEventSourceRef = useRef<EventSource | null>(null);
+  const aiTranscriptEventSourceRef = useRef<EventSource | null>(null);
+  const userTranscriptEventSourceRef = useRef<EventSource | null>(null);
+  const hasAiTranscriptSseRef = useRef(false);
+  const hasUserTranscriptSseRef = useRef(false);
   const hasCapturedAudioRef = useRef(false);
   const latestConversationRef = useRef<StoredConversation | null>(null);
-  const currentUserMessageRef = useRef<{ id: string; order: number } | null>(null);
 
-  const userPendingTextRef = useRef('');
-  const userTypingIntervalRef = useRef<number | null>(null);
+  const hostActiveIdRef = useRef<string | null>(null);
+  const aiActiveIdRef = useRef<string | null>(null);
+  const hostPendingRef = useRef("");
+  const aiPendingRef = useRef("");
+  const hostTypingIntervalRef = useRef<number | null>(null);
+  const aiTypingIntervalRef = useRef<number | null>(null);
+
   const transcriptScrollRef = useRef<HTMLDivElement | null>(null);
-  const transcriptEndRef = useRef<HTMLDivElement | null>(null);
-  const userTranscriptEventSourceRef = useRef<EventSource | null>(null);
-  const aiTranscriptEventSourceRef = useRef<EventSource | null>(null);
-  const hasUserTranscriptSseRef = useRef(false);
-  const hasAiTranscriptSseRef = useRef(false);
-  const isCommittingRef = useRef(false);
-  const isUserSpeakingRef = useRef(false);
-
-  const sortMessages = useCallback((list: ConversationMessage[]) => {
-    return [...list].sort((a, b) => {
-      if (a.order !== b.order) {
-        return a.order - b.order;
-      }
-      return a.timestamp.getTime() - b.timestamp.getTime();
-    });
-  }, []);
-
-  const updateIsUserSpeaking = useCallback((value: boolean) => {
-    isUserSpeakingRef.current = value;
-    setIsUserSpeaking(value);
-  }, []);
-
-  const appendMessage = useCallback((message: ConversationMessage) => {
-    setMessages((previous) => sortMessages([...previous, message]));
-  }, [sortMessages]);
-
-  const updateMessageContent = useCallback((id: string, updater: (message: ConversationMessage) => ConversationMessage) => {
-    setMessages((previous) => sortMessages(previous.map((message) => {
-      if (message.id !== id) {
-        return message;
-      }
-      return updater(message);
-    })));
-  }, [sortMessages]);
-
-  const base64ToUint8Array = useCallback((base64: string): Uint8Array => {
-    const sanitized = (base64 || '').replace(/\s+/g, '');
-
-    if (typeof window !== 'undefined' && typeof window.atob === 'function') {
-      const binary = window.atob(sanitized);
-      const bytes = new Uint8Array(binary.length);
-      for (let index = 0; index < binary.length; index++) {
-        bytes[index] = binary.charCodeAt(index);
-      }
-      return bytes;
-    }
-
-    if (typeof Buffer !== 'undefined') {
-      return Uint8Array.from(Buffer.from(sanitized, 'base64'));
-    }
-
-    throw new Error('Base64 decoding is not supported in this environment.');
-  }, []);
-
-  const stopUserTyping = useCallback(() => {
-    if (userTypingIntervalRef.current != null) {
-      window.clearInterval(userTypingIntervalRef.current);
-      userTypingIntervalRef.current = null;
-    }
-  }, []);
-
-  const resetUserTranscriptionState = useCallback(() => {
-    userPendingTextRef.current = '';
-    setUserTranscriptionDisplay('');
-    stopUserTyping();
-    updateIsUserSpeaking(false);
-    setIsTranscribing(false);
-    currentUserMessageRef.current = null;
-    setActiveUserMessageId(null);
-  }, [stopUserTyping, updateIsUserSpeaking, setActiveUserMessageId]);
-
-  const startUserTyping = useCallback(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if (userTypingIntervalRef.current != null) {
-      return;
-    }
-
-    userTypingIntervalRef.current = window.setInterval(() => {
-      if (!userPendingTextRef.current) {
-        return;
-      }
-
-      const [chunk, rest] = nextWordChunk(userPendingTextRef.current);
-      if (!chunk) {
-        userPendingTextRef.current = rest;
-        return;
-      }
-
-      userPendingTextRef.current = rest;
-      setUserTranscriptionDisplay((previous) => previous + chunk);
-
-      const activeMessage = currentUserMessageRef.current;
-      if (activeMessage) {
-        updateMessageContent(activeMessage.id, (message) => ({
-          ...message,
-          content: message.content + chunk,
-        }));
-      }
-    }, 32);
-  }, [updateMessageContent]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const loadSelectedPaper = () => {
-      const stored = sessionStorage.getItem("vps:selectedPaper");
-
-      if (!stored) {
-        setCurrentPaper(null);
-        setPaperLoadError(null);
-        return;
-      }
-
-      try {
-        const parsed = JSON.parse(stored) as SelectedPaper | null;
-
-        if (!parsed || typeof parsed !== "object" || !("id" in parsed) || !parsed.id) {
-          throw new Error("Invalid stored paper payload");
-        }
-
-        setCurrentPaper(parsed);
-        setPaperLoadError(null);
-      } catch (error) {
-        console.error("Failed to load stored paper:", error);
-        setCurrentPaper(null);
-        setPaperLoadError(
-          "We couldn't load the selected paper. Please return to the Research Hub and choose a paper before starting the Audio Studio.",
-        );
-      }
-    };
-
-    loadSelectedPaper();
-
-    const handleStorage = (event: StorageEvent) => {
-      if (event.storageArea === sessionStorage && event.key === "vps:selectedPaper") {
-        loadSelectedPaper();
-      }
-    };
-
-    window.addEventListener("storage", handleStorage);
-
-    return () => {
-      window.removeEventListener("storage", handleStorage);
-    };
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      resetUserTranscriptionState();
-    };
-  }, [resetUserTranscriptionState]);
 
   const paperPayload = useMemo(() => {
     if (!currentPaper) {
@@ -497,19 +347,66 @@ export default function Studio() {
     };
   }, [currentPaper]);
 
-  // Timer for session duration
   useEffect(() => {
-    let interval: NodeJS.Timeout;
-    if (isRecording) {
-      interval = setInterval(() => {
-        setSessionDuration(prev => prev + 1);
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const loadSelectedPaper = () => {
+      const stored = sessionStorage.getItem("vps:selectedPaper");
+
+      if (!stored) {
+        setCurrentPaper(null);
+        setPaperLoadError(null);
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stored) as SelectedPaper | null;
+        if (!parsed || typeof parsed !== "object" || !("id" in parsed) || !parsed.id) {
+          throw new Error("Invalid stored paper payload");
+        }
+        setCurrentPaper(parsed);
+        setPaperLoadError(null);
+      } catch (err) {
+        console.error("Failed to load stored paper:", err);
+        setCurrentPaper(null);
+        setPaperLoadError(
+          "We couldn't load the selected paper. Return to the Research Hub to pick a paper before recording.",
+        );
+      }
+    };
+
+    loadSelectedPaper();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.storageArea === sessionStorage && event.key === "vps:selectedPaper") {
+        loadSelectedPaper();
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    let interval: number | undefined;
+    if (phase === "live") {
+      interval = window.setInterval(() => {
+        setSessionDuration((prev) => prev + 1);
       }, 1000);
     }
-    return () => clearInterval(interval);
-  }, [isRecording]);
+    return () => {
+      if (interval) {
+        window.clearInterval(interval);
+      }
+    };
+  }, [phase]);
 
   const scrollToLatest = useCallback(() => {
-    if (typeof window === 'undefined') {
+    if (typeof window === "undefined") {
       return;
     }
 
@@ -518,261 +415,248 @@ export default function Studio() {
       if (!root) {
         return;
       }
-
       const viewport = root.querySelector<HTMLDivElement>('[data-slot="scroll-area-viewport"]');
       if (viewport) {
-        if (typeof viewport.scrollTo === 'function') {
-          viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
+        const scrollOptions: ScrollToOptions = {
+          top: viewport.scrollHeight,
+          behavior: "smooth",
+        };
+        if (typeof viewport.scrollTo === "function") {
+          viewport.scrollTo(scrollOptions);
         } else {
           viewport.scrollTop = viewport.scrollHeight;
         }
         return;
       }
-
-      if (transcriptEndRef.current) {
-        transcriptEndRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
-      }
+      root.scrollIntoView({ behavior: "smooth", block: "end" });
     });
   }, []);
 
-  const sendDataChannelSessionUpdate = useCallback(() => {
-    const channel = dcRef.current;
-    if (!channel || channel.readyState !== 'open') {
-      return;
-    }
-
-    try {
-      const instructions = buildConversationInstructionsFromPaper(currentPaper);
-      channel.send(JSON.stringify({
-        type: 'session.update',
-        session: {
-          modalities: ['text', 'audio'],
-          voice: 'alloy',
-          input_audio_transcription: { model: 'whisper-1' },
-          turn_detection: { type: 'server_vad', threshold: 0.5, prefix_padding_ms: 300, silence_duration_ms: 800 },
-          instructions,
-        },
-      }));
-    } catch (err) {
-      console.error('[ERROR] Failed to send session update over data channel:', err);
-    }
-  }, [currentPaper]);
-
   useEffect(() => {
     scrollToLatest();
-  }, [messages, userTranscriptionDisplay, isTranscribing, scrollToLatest]);
+  }, [entries, isHostSpeaking, isAiSpeaking, scrollToLatest]);
 
-  useEffect(() => {
-    sendDataChannelSessionUpdate();
-  }, [sendDataChannelSessionUpdate]);
-
-  // Fast typing animation helpers for AI transcript
-  const startAiTyping = useCallback(() => {
-    if (aiTypingIntervalRef.current != null) {
-      return;
+  const startSegment = useCallback((speaker: Speaker) => {
+    const id = `${speaker}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    const startedAt = Date.now();
+    setEntries((prev) => [
+      ...prev,
+      {
+        id,
+        speaker,
+        text: "",
+        status: "streaming",
+        startedAt,
+        updatedAt: startedAt,
+      },
+    ]);
+    if (speaker === "host") {
+      hostActiveIdRef.current = id;
+    } else {
+      aiActiveIdRef.current = id;
     }
+    return id;
+  }, []);
 
-    aiTypingIntervalRef.current = window.setInterval(() => {
-      if (!aiAudioStartedRef.current && aiTextBufferRef.current.length === 0) {
-        clearInterval(aiTypingIntervalRef.current!);
-        aiTypingIntervalRef.current = null;
-        setActiveAiMessageId(null);
+  const ensureSegment = useCallback((speaker: Speaker) => {
+    if (speaker === "host") {
+      if (!hostActiveIdRef.current) {
+        const id = startSegment("host");
+        setIsHostSpeaking(true);
+        return id;
+      }
+      setIsHostSpeaking(true);
+      return hostActiveIdRef.current;
+    }
+    if (!aiActiveIdRef.current) {
+      const id = startSegment("ai");
+      setIsAiSpeaking(true);
+      return id;
+    }
+    setIsAiSpeaking(true);
+    return aiActiveIdRef.current;
+  }, [startSegment]);
+
+  const updateEntryText = useCallback((id: string, updater: (value: string) => string) => {
+    const updatedAt = Date.now();
+    setEntries((prev) =>
+      prev.map((entry) =>
+        entry.id === id
+          ? {
+              ...entry,
+              text: updater(entry.text),
+              updatedAt,
+            }
+          : entry,
+      ),
+    );
+  }, []);
+
+  const markEntryFinal = useCallback((id: string) => {
+    const completedAt = Date.now();
+    setEntries((prev) =>
+      prev.map((entry) =>
+        entry.id === id
+          ? {
+              ...entry,
+              status: "final",
+              completedAt,
+            }
+          : entry,
+      ),
+    );
+  }, []);
+
+  const drainPending = useCallback(
+    (speaker: Speaker, flushAll: boolean) => {
+      const pendingRef = speaker === "host" ? hostPendingRef : aiPendingRef;
+      const pending = pendingRef.current;
+      if (!pending) {
         return;
       }
 
-      if (aiTextBufferRef.current.length === 0) {
+      let activeId: string | null;
+      if (speaker === "host") {
+        activeId = hostActiveIdRef.current;
+        if (!activeId) {
+          activeId = ensureSegment("host");
+        }
+      } else {
+        activeId = aiActiveIdRef.current;
+        if (!activeId) {
+          activeId = ensureSegment("ai");
+        }
+      }
+
+      if (!activeId) {
         return;
       }
 
-      if (!lastAiMessageIdRef.current) {
-        const id = `ai_${Date.now()}`;
-        lastAiMessageIdRef.current = id;
-        const order = ++messageSequenceRef.current;
-        appendMessage({
-          id,
-          role: 'expert',
-          content: '',
-          timestamp: new Date(),
-          type: 'text',
-          speaker: 'Dr. Sarah (AI Expert)',
-          order,
-        });
-        setActiveAiMessageId(id);
+      if (flushAll) {
+        const chunk = pending;
+        pendingRef.current = "";
+        updateEntryText(activeId, (value) => value + chunk);
+        return;
       }
 
-      const maxPerTick = Math.min(64, Math.max(2, Math.floor(aiTextBufferRef.current.length / 8)));
-      const chunk = aiTextBufferRef.current.slice(0, maxPerTick);
-      aiTextBufferRef.current = aiTextBufferRef.current.slice(maxPerTick);
-
-      if (lastAiMessageIdRef.current) {
-        const targetId = lastAiMessageIdRef.current;
-        updateMessageContent(targetId, (message) => ({ ...message, content: message.content + chunk }));
+      const [chunk, rest] = nextWordChunk(pending);
+      if (!chunk) {
+        pendingRef.current = rest;
+        return;
       }
-    }, 16);
-  }, [appendMessage, updateMessageContent]);
 
-  const flushAiTyping = useCallback((stop: boolean) => {
-    if (aiTextBufferRef.current.length > 0 && lastAiMessageIdRef.current) {
-      const chunk = aiTextBufferRef.current;
-      aiTextBufferRef.current = '';
-      const targetId = lastAiMessageIdRef.current;
-      updateMessageContent(targetId, (message) => ({ ...message, content: message.content + chunk }));
+      pendingRef.current = rest;
+      updateEntryText(activeId, (value) => value + chunk);
+    },
+    [ensureSegment, updateEntryText],
+  );
+
+  const stopTypingInterval = useCallback((speaker: Speaker) => {
+    const ref = speaker === "host" ? hostTypingIntervalRef : aiTypingIntervalRef;
+    if (ref.current != null) {
+      window.clearInterval(ref.current);
+      ref.current = null;
     }
+  }, []);
 
-    if (stop && aiTypingIntervalRef.current != null) {
-      clearInterval(aiTypingIntervalRef.current);
-      aiTypingIntervalRef.current = null;
-    }
-
-    if (stop) {
-      lastAiMessageIdRef.current = null;
-      setActiveAiMessageId(null);
-    }
-  }, [updateMessageContent]);
-
-  const handleAiTranscriptDelta = useCallback((text: string) => {
-    if (!text) {
-      return;
-    }
-
-    aiTextBufferRef.current += text;
-    startAiTyping();
-  }, [startAiTyping]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    if (!isConnected) {
-      if (audioEventSourceRef.current) {
-        audioEventSourceRef.current.close();
-        audioEventSourceRef.current = null;
+  const ensureTypingInterval = useCallback(
+    (speaker: Speaker) => {
+      const ref = speaker === "host" ? hostTypingIntervalRef : aiTypingIntervalRef;
+      if (ref.current != null) {
+        return;
       }
-      if (userTranscriptEventSourceRef.current) {
-        userTranscriptEventSourceRef.current.close();
-        userTranscriptEventSourceRef.current = null;
+      const tick = speaker === "host" ? 36 : 28;
+      ref.current = window.setInterval(() => {
+        drainPending(speaker, false);
+      }, tick);
+    },
+    [drainPending],
+  );
+
+  const appendToSegment = useCallback(
+    (speaker: Speaker, delta: string) => {
+      if (!delta) {
+        return;
       }
-      if (aiTranscriptEventSourceRef.current) {
-        aiTranscriptEventSourceRef.current.close();
-        aiTranscriptEventSourceRef.current = null;
+      ensureSegment(speaker);
+      const pendingRef = speaker === "host" ? hostPendingRef : aiPendingRef;
+      pendingRef.current += delta;
+      ensureTypingInterval(speaker);
+      drainPending(speaker, false);
+    },
+    [drainPending, ensureSegment, ensureTypingInterval],
+  );
+
+  const finalizeSegment = useCallback(
+    (speaker: Speaker, finalText?: string) => {
+      const pendingRef = speaker === "host" ? hostPendingRef : aiPendingRef;
+      const activeRef = speaker === "host" ? hostActiveIdRef : aiActiveIdRef;
+      if (!activeRef.current && !pendingRef.current && !finalText) {
+        if (speaker === "host") {
+          setIsHostSpeaking(false);
+        } else {
+          setIsAiSpeaking(false);
+        }
+        return;
       }
-      hasUserTranscriptSseRef.current = false;
-      hasAiTranscriptSseRef.current = false;
-      return;
-    }
 
-    if (audioEventSourceRef.current) {
-      return;
-    }
-
-    try {
-      const source = new EventSource(`/api/rt/audio?sessionId=${sessionId}`);
-      audioEventSourceRef.current = source;
-
-      source.addEventListener("connected", () => {
-        console.log("[INFO] Connected to AI audio stream");
-      });
-
-      source.onmessage = (event) => {
-        const payload = (event.data || "").trim();
-        if (!payload || payload === "Audio stream ready") {
-          return;
-        }
-
-        try {
-          const binary = atob(payload);
-          const bytes = new Uint8Array(binary.length);
-          for (let i = 0; i < binary.length; i++) {
-            bytes[i] = binary.charCodeAt(i);
-          }
-          aiAudioChunksRef.current.push(bytes);
-          if (!hasCapturedAudioRef.current) {
-            hasCapturedAudioRef.current = true;
-            setHasCapturedAudio(true);
-          }
-        } catch (error) {
-          console.error("[ERROR] Failed to capture AI audio chunk", error);
-        }
-      };
-
-      source.addEventListener("error", (event) => {
-        console.error("[ERROR] AI audio SSE stream error", event);
-      });
-
-      return () => {
-        source.close();
-        if (audioEventSourceRef.current === source) {
-          audioEventSourceRef.current = null;
-        }
-      };
-    } catch (error) {
-      console.error("[ERROR] Unable to open AI audio SSE stream", error);
-    }
-  }, [isConnected, sessionId]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if (!isConnected) {
-      if (aiTranscriptEventSourceRef.current) {
-        aiTranscriptEventSourceRef.current.close();
-        aiTranscriptEventSourceRef.current = null;
+      if (!activeRef.current) {
+        ensureSegment(speaker);
       }
-      hasAiTranscriptSseRef.current = false;
-      return;
+
+      if (finalText) {
+        pendingRef.current += finalText;
+      }
+
+      drainPending(speaker, true);
+
+      const activeId = activeRef.current;
+      if (activeId) {
+        markEntryFinal(activeId);
+      }
+      activeRef.current = null;
+      pendingRef.current = "";
+      stopTypingInterval(speaker);
+
+      if (speaker === "host") {
+        setIsHostSpeaking(false);
+      } else {
+        setIsAiSpeaking(false);
+      }
+    },
+    [drainPending, ensureSegment, markEntryFinal, stopTypingInterval],
+  );
+
+  const resetConversation = useCallback(() => {
+    hostActiveIdRef.current = null;
+    aiActiveIdRef.current = null;
+    hostPendingRef.current = "";
+    aiPendingRef.current = "";
+    stopTypingInterval("host");
+    stopTypingInterval("ai");
+    setIsHostSpeaking(false);
+    setIsAiSpeaking(false);
+    setEntries([]);
+  }, [stopTypingInterval]);
+
+  const base64ToUint8Array = useCallback((base64: string): Uint8Array => {
+    const sanitized = (base64 || "").replace(/\s+/g, "");
+
+    if (typeof window !== "undefined" && typeof window.atob === "function") {
+      const binary = window.atob(sanitized);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      return bytes;
     }
 
-    if (aiTranscriptEventSourceRef.current) {
-      return;
+    if (typeof Buffer !== "undefined") {
+      return Uint8Array.from(Buffer.from(sanitized, "base64"));
     }
 
-    try {
-      const source = new EventSource(`/api/rt/transcripts?sessionId=${sessionId}`);
-      aiTranscriptEventSourceRef.current = source;
-      hasAiTranscriptSseRef.current = true;
-
-      source.onmessage = (event) => {
-        const data = (event.data || '').trim();
-        if (!data || data === 'Connected to AI transcript stream') {
-          return;
-        }
-        handleAiTranscriptDelta(data);
-      };
-
-      source.addEventListener('done', () => {
-        flushAiTyping(true);
-      });
-
-      source.addEventListener('error', (event) => {
-        console.error('[ERROR] AI transcript SSE stream error', event);
-        hasAiTranscriptSseRef.current = false;
-        if (aiTranscriptEventSourceRef.current === source) {
-          source.close();
-          aiTranscriptEventSourceRef.current = null;
-        }
-      });
-
-      return () => {
-        source.close();
-        if (aiTranscriptEventSourceRef.current === source) {
-          aiTranscriptEventSourceRef.current = null;
-        }
-        hasAiTranscriptSseRef.current = false;
-      };
-    } catch (error) {
-      console.error('[ERROR] Unable to open AI transcript SSE stream', error);
-      hasAiTranscriptSseRef.current = false;
-    }
-  }, [flushAiTyping, handleAiTranscriptDelta, isConnected, sessionId]);
-
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  };
+    throw new Error("Base64 decoding is not supported in this environment.");
+  }, []);
 
   const ensureRealtimeSession = useCallback(async () => {
     const friendlyProvider = activeProvider === "openai" ? "OpenAI" : "Google";
@@ -782,19 +666,21 @@ export default function Studio() {
     }
 
     if (activeProvider === "google") {
-      throw new Error("Realtime studio currently supports only OpenAI sessions. Switch your active provider in Settings to continue.");
+      throw new Error(
+        "Realtime studio currently supports only OpenAI sessions. Switch your active provider in Settings to continue.",
+      );
     }
 
-    const response = await fetch('/api/rt/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const response = await fetch("/api/rt/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sessionId,
         provider: activeProvider,
         apiKey: activeApiKey,
         paper: paperPayload ?? undefined,
       }),
-      cache: 'no-store'
+      cache: "no-store",
     });
 
     let payload: { error?: string } | null = null;
@@ -810,290 +696,90 @@ export default function Studio() {
     }
   }, [activeApiKey, activeProvider, paperPayload, sessionId]);
 
-  // (moved earlier) startAiTyping, flushAiTyping, handleAiTranscriptDelta
-
-  const handleUserTranscriptionStarted = useCallback(() => {
-    if (!isUserSpeakingRef.current) {
-      userPendingTextRef.current = '';
-      setUserTranscriptionDisplay('');
-    }
-
-    if (!currentUserMessageRef.current) {
-      const id = `user_${Date.now()}`;
-      const order = ++messageSequenceRef.current;
-      currentUserMessageRef.current = { id, order };
-      appendMessage({
-        id,
-        role: 'user',
-        content: '',
-        timestamp: new Date(),
-        type: 'text',
-        speaker: 'Host (You)',
-        order,
-      });
-      setActiveUserMessageId(id);
-    } else {
-      const activeMessage = currentUserMessageRef.current;
-      if (activeMessage) {
-        setActiveUserMessageId(activeMessage.id);
-      }
-    }
-
-    stopUserTyping();
-    updateIsUserSpeaking(true);
-    setIsTranscribing(true);
-  }, [appendMessage, setActiveUserMessageId, stopUserTyping, updateIsUserSpeaking]);
-
-  const handleUserTranscriptionDelta = useCallback((delta: string) => {
-    if (!delta) {
-      return;
-    }
-
-    if (!isUserSpeakingRef.current) {
-      handleUserTranscriptionStarted();
-    } else {
-      updateIsUserSpeaking(true);
-      setIsTranscribing(true);
-    }
-
-    userPendingTextRef.current += delta;
-    startUserTyping();
-  }, [handleUserTranscriptionStarted, startUserTyping, updateIsUserSpeaking]);
-
   const commitAudioTurn = useCallback(async () => {
-    if (!isConnected || !isSessionReady) {
+    if (phase !== "live") {
       return;
     }
-
     if (isCommittingRef.current) {
       return;
     }
-
     isCommittingRef.current = true;
     try {
-      const response = await fetch('/api/rt/audio-commit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch("/api/rt/audio-commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId }),
-        cache: 'no-store'
+        cache: "no-store",
       });
-
       if (!response.ok) {
         const payload = await response.json().catch(() => ({}));
-        const message = typeof payload?.error === 'string' ? payload.error : 'Failed to commit audio turn';
-        console.warn('[WARN] Audio commit request failed', { message, status: response.status });
+        const message = typeof payload?.error === "string" ? payload.error : "Failed to commit audio turn";
+        console.warn("[WARN] Audio commit request failed", { message, status: response.status });
       }
-    } catch (error) {
-      console.error('[ERROR] Audio commit request failed', error);
+    } catch (err) {
+      console.error("[ERROR] Audio commit request failed", err);
     } finally {
       isCommittingRef.current = false;
     }
-  }, [isConnected, isSessionReady, sessionId]);
+  }, [phase, sessionId]);
 
-  const handleUserTranscriptionComplete = useCallback((transcript: string) => {
-    const finalTranscript = transcript.trim();
-    if (finalTranscript) {
-      const activeMessage = currentUserMessageRef.current;
-      if (activeMessage) {
-        updateMessageContent(activeMessage.id, (message) => ({
-          ...message,
-          content: finalTranscript,
-          timestamp: new Date(),
-        }));
-      } else {
-        const order = ++messageSequenceRef.current;
-        appendMessage({
-          id: `user_${Date.now()}`,
-          role: 'user',
-          content: finalTranscript,
-          timestamp: new Date(),
-          type: 'text',
-          speaker: 'Host (You)',
-          order,
-        });
-      }
+  const stopMicrophonePipeline = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.stop();
+      mediaRecorderRef.current = null;
     }
-
-    resetUserTranscriptionState();
-    void commitAudioTurn();
-  }, [appendMessage, commitAudioTurn, resetUserTranscriptionState, updateMessageContent]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
+    if (micFlushIntervalRef.current != null) {
+      window.clearInterval(micFlushIntervalRef.current);
+      micFlushIntervalRef.current = null;
     }
+    micChunkQueueRef.current = [];
+    isUploadingRef.current = false;
+    setIsRecording(false);
+  }, []);
 
-    if (!isConnected) {
-      if (userTranscriptEventSourceRef.current) {
-        userTranscriptEventSourceRef.current.close();
-        userTranscriptEventSourceRef.current = null;
-      }
-      hasUserTranscriptSseRef.current = false;
-      return;
-    }
-
-    if (userTranscriptEventSourceRef.current) {
-      return;
-    }
-
-    try {
-      const source = new EventSource(`/api/rt/user-transcripts?sessionId=${sessionId}`);
-      userTranscriptEventSourceRef.current = source;
-      hasUserTranscriptSseRef.current = true;
-
-      const handleComplete = (event: MessageEvent) => {
-        const data = (event.data || '').trim();
-        if (!data || data === 'Connected to user transcript stream') {
-          if (!data) {
-            resetUserTranscriptionState();
-          }
-          return;
-        }
-
-        handleUserTranscriptionComplete(data);
-      };
-
-      const handleDelta = (event: MessageEvent) => {
-        const data = (event.data || '').trim();
-        if (!data || data === 'Connected to user transcript stream') {
-          return;
-        }
-        handleUserTranscriptionDelta(data);
-      };
-
-      source.addEventListener('complete', handleComplete);
-      source.addEventListener('delta', handleDelta);
-      source.addEventListener('error', (event) => {
-        console.error('[ERROR] User transcript SSE stream error', event);
-        hasUserTranscriptSseRef.current = false;
-        if (userTranscriptEventSourceRef.current === source) {
-          source.close();
-          userTranscriptEventSourceRef.current = null;
-        }
-      });
-
-      return () => {
-        source.removeEventListener('complete', handleComplete);
-        source.removeEventListener('delta', handleDelta);
-        source.close();
-        if (userTranscriptEventSourceRef.current === source) {
-          userTranscriptEventSourceRef.current = null;
-        }
-        hasUserTranscriptSseRef.current = false;
-      };
-    } catch (error) {
-      console.error('[ERROR] Unable to open user transcript SSE stream', error);
-      hasUserTranscriptSseRef.current = false;
-    }
-  }, [handleUserTranscriptionComplete, handleUserTranscriptionDelta, isConnected, resetUserTranscriptionState, sessionId]);
-
-  const handleSendText = async () => {
-    const trimmed = textInput.trim();
-    if (!trimmed) {
-      return;
-    }
-
-    if (!isConnected || !isSessionReady) {
-      setStatusMessage(null);
-      setError('Connect to the AI session before sending a message.');
-      return;
-    }
-
-    try {
-      setError(null);
-      await ensureRealtimeSession();
-
-      const order = ++messageSequenceRef.current;
-      const userMessage: ConversationMessage = {
-        id: `msg_${Date.now()}`,
-        role: 'user',
-        content: trimmed,
-        timestamp: new Date(),
-        type: 'text',
-        speaker: 'Host (You)',
-        order,
-      };
-
-      appendMessage(userMessage);
-      setTextInput("");
-
-      const response = await fetch('/api/rt/text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: trimmed, sessionId }),
-        cache: 'no-store'
-      });
-
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({}));
-        throw new Error(payload?.error || 'Failed to send text to AI');
-      }
-    } catch (error) {
-      console.error('Error sending text:', error);
-      setStatusMessage(null);
-      setError(error instanceof Error ? error.message : 'Failed to send message');
-    }
-  };
-
-  const startMicrophoneRecording = async () => {
+  const startMicrophonePipeline = useCallback(async () => {
     try {
       await ensureRealtimeSession();
-    } catch (error) {
-      console.error('[ERROR] Realtime session not ready for microphone recording:', error);
+    } catch (err) {
       setStatusMessage(null);
-      setError(error instanceof Error ? error.message : 'Failed to start realtime session.');
+      setError(err instanceof Error ? err.message : "Failed to start realtime session.");
       return false;
     }
 
     try {
-      console.log('[INFO] Starting microphone recording', { sessionId });
-
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           sampleRate: 24000,
           channelCount: 1,
           echoCancellation: true,
-          noiseSuppression: true
-        }
+          noiseSuppression: true,
+        },
       });
 
-      console.log('[DEBUG] Microphone access granted');
-      
-      // Create AudioContext for proper PCM16 conversion - MUST match input sample rate
       if (!audioContextRef.current) {
         const AudioContextConstructor =
           window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
         if (!AudioContextConstructor) {
-          throw new Error('Web Audio API is not supported in this browser.');
+          throw new Error("Web Audio API is not supported in this browser.");
         }
         audioContextRef.current = new AudioContextConstructor({ sampleRate: 24000 });
       }
-      
+
       const audioContext = audioContextRef.current;
-      
-      // Resume context if suspended
-      if (audioContext.state === 'suspended') {
+      if (audioContext.state === "suspended") {
         await audioContext.resume();
       }
-      
-      const source = audioContext.createMediaStreamSource(stream);
-      
-      // Use smaller buffer for lower latency
-      const scriptProcessor = audioContext.createScriptProcessor(1024, 1, 1);
-      
-      scriptProcessor.onaudioprocess = async (event) => {
-        const inputBuffer = event.inputBuffer;
-        const inputData = inputBuffer.getChannelData(0);
 
-        // Convert Float32 to PCM16 with better precision
+      const source = audioContext.createMediaStreamSource(stream);
+      const scriptProcessor = audioContext.createScriptProcessor(1024, 1, 1);
+
+      scriptProcessor.onaudioprocess = (event) => {
+        const inputData = event.inputBuffer.getChannelData(0);
         const pcm16Buffer = new Int16Array(inputData.length);
         for (let i = 0; i < inputData.length; i++) {
-          // Clamp to [-1, 1] and convert to 16-bit integer
           const sample = Math.max(-1, Math.min(1, inputData[i]));
           pcm16Buffer[i] = Math.round(sample * 32767);
         }
-
-        // Queue chunk for batched upload
         const uint8Array = new Uint8Array(pcm16Buffer.buffer);
         micChunkQueueRef.current.push(uint8Array);
         hostAudioChunksRef.current.push(new Uint8Array(uint8Array));
@@ -1102,17 +788,14 @@ export default function Studio() {
           setHasCapturedAudio(true);
         }
       };
-      
+
       source.connect(scriptProcessor);
-      // Do NOT connect to destination to avoid echo/feedback
-      
-      // Start a fast flush loop to batch-send queued chunks
+
       const flush = async () => {
         if (isUploadingRef.current) return;
         if (micChunkQueueRef.current.length === 0) return;
         isUploadingRef.current = true;
         try {
-          // Concatenate queued chunks
           const totalLength = micChunkQueueRef.current.reduce((sum, chunk) => sum + chunk.length, 0);
           const combined = new Uint8Array(totalLength);
           let offset = 0;
@@ -1121,433 +804,127 @@ export default function Studio() {
             offset += chunk.length;
           }
           micChunkQueueRef.current = [];
-          // Base64 encode safely
-          let binary = '';
+          let binary = "";
           const CHUNK_SIZE = 0x8000;
           for (let i = 0; i < combined.length; i += CHUNK_SIZE) {
             const chunk = combined.subarray(i, i + CHUNK_SIZE);
             binary += String.fromCharCode(...chunk);
           }
           const base64 = btoa(binary);
-          const response = await fetch('/api/rt/audio-append', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ base64, sessionId })
+          const response = await fetch("/api/rt/audio-append", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ base64, sessionId }),
           });
           if (!response.ok) {
             const errJson = await response.json().catch(() => ({}));
-            console.error('[ERROR] Failed to send batched audio:', errJson);
+            console.error("[ERROR] Failed to send batched audio:", errJson);
           }
         } catch (e) {
-          console.error('[ERROR] Mic flush failed:', e);
+          console.error("[ERROR] Mic flush failed:", e);
         } finally {
           isUploadingRef.current = false;
         }
       };
+
       if (micFlushIntervalRef.current == null) {
         micFlushIntervalRef.current = window.setInterval(flush, 50);
       }
 
-      // Store references for cleanup
-      const processor: MicrophoneProcessor = {
+      const processor = {
         stop: () => {
-          console.log('[INFO] Stopping audio processing');
           source.disconnect();
           scriptProcessor.disconnect();
-          stream.getTracks().forEach(track => track.stop());
+          stream.getTracks().forEach((track) => track.stop());
           if (micFlushIntervalRef.current != null) {
-            clearInterval(micFlushIntervalRef.current);
+            window.clearInterval(micFlushIntervalRef.current);
             micFlushIntervalRef.current = null;
           }
-        }
+        },
       };
-      mediaRecorderRef.current = processor;
 
-      // Don't manually commit - let server VAD handle turn detection
-      console.log('[DEBUG] Real-time PCM16 audio processing started - server VAD will detect turn endings');
+      mediaRecorderRef.current = processor;
+      setIsRecording(true);
       return true;
     } catch (error) {
-      console.error('[ERROR] Failed to access microphone:', error);
+      console.error("[ERROR] Failed to access microphone:", error);
       setStatusMessage(null);
-      setError('Failed to access microphone. Please check permissions.');
+      setError("Failed to access microphone. Please check permissions.");
       return false;
     }
-  };
-
-  const handleStartRecording = async () => {
-    if (!isConnected) {
-      setStatusMessage(null);
-      setError('Please connect to AI first');
-      return;
-    }
-
-    setError(null);
-    setStatusMessage(null);
-    const success = await startMicrophoneRecording();
-    if (success) {
-      setIsRecording(true);
-    }
-  };
-
-  const handleStopRecording = async () => {
-    console.log('[INFO] Stopping recording manually - server VAD will handle the rest');
-    if (mediaRecorderRef.current) {
-      mediaRecorderRef.current.stop(); // Don't await, just stop immediately
-      mediaRecorderRef.current = null;
-    }
-    setIsRecording(false);
-  };
-
-  const handleConnect = async () => {
-    if (isConnecting) {
-      return;
-    }
-
-    setIsConnecting(true);
-    setError(null);
-    setStatusMessage(null);
-    setIsConnected(false);
-    setIsSessionReady(false);
-    setIsAudioPlaying(false);
-    hostAudioChunksRef.current = [];
-    aiAudioChunksRef.current = [];
-    audioEventSourceRef.current?.close();
-    audioEventSourceRef.current = null;
-    latestConversationRef.current = null;
-    hasCapturedAudioRef.current = false;
-    setHasCapturedAudio(false);
-    messageSequenceRef.current = 0;
-    setActiveAiMessageId(null);
-    resetUserTranscriptionState();
-
-    let pc: RTCPeerConnection | null = null;
-    let localStream: MediaStream | null = null;
-
-    try {
-      if (!activeApiKey) {
-        setStatusMessage(null);
-        setError(`Add your ${providerLabel} API key in Settings before connecting.`);
-        setIsConnecting(false);
-        return;
-      }
-
-      if (activeProvider === "google") {
-        setStatusMessage(null);
-        setError("Google's Gemini APIs do not support realtime audio in this studio yet. Switch to OpenAI to continue.");
-        setIsConnecting(false);
-        return;
-      }
-
-      await ensureRealtimeSession();
-
-      console.log('[INFO] Starting WebRTC connection process', { sessionId });
-
-      if (pcRef.current) {
-        try {
-          pcRef.current.getSenders().forEach(sender => sender.track?.stop());
-        } catch {}
-        pcRef.current.close();
-        pcRef.current = null;
-      }
-
-      if (dcRef.current) {
-        try { dcRef.current.close(); } catch {}
-        dcRef.current = null;
-      }
-
-      pc = new RTCPeerConnection({
-        iceServers: [
-          { urls: ['stun:stun.l.google.com:19302'] }
-        ]
-      });
-
-      pc.ontrack = (event) => {
-        const [remoteStream] = event.streams;
-        const audioElement = audioRef.current;
-
-        if (audioElement) {
-          audioElement.srcObject = remoteStream;
-          const playPromise = audioElement.play();
-          if (playPromise !== undefined) {
-            playPromise.catch(err => {
-              console.warn('[WARN] Autoplay prevented for remote audio:', err);
-            });
-          }
-        } else {
-          const fallback = new Audio();
-          fallback.srcObject = remoteStream;
-          fallback.autoplay = true;
-          fallback.play().catch(() => {});
-        }
-
-        const track = event.track;
-        aiTrackRef.current = track;
-        track.onunmute = () => {
-          aiAudioStartedRef.current = true;
-          startAiTyping();
-        };
-        track.onmute = () => {
-          aiAudioStartedRef.current = false;
-        };
-        track.onended = () => {
-          aiAudioStartedRef.current = false;
-        };
-      };
-
-      const handleDcMessage = (data: unknown) => {
-        if (typeof data !== 'string') {
-          return;
-        }
-
-        try {
-          const msg = JSON.parse(data) as Record<string, unknown>;
-          const type = typeof msg.type === 'string' ? msg.type : '';
-          if (!type) {
-            return;
-          }
-
-          if (!hasAiTranscriptSseRef.current && (type === 'response.output_text.delta' || type === 'response.text.delta' || type === 'response.audio_transcript.delta')) {
-            const deltaText = typeof msg.delta === 'string' ? msg.delta : '';
-            const responseText = typeof msg.text === 'string' ? msg.text : '';
-            const text = deltaText || responseText;
-            if (text) {
-              handleAiTranscriptDelta(text);
-            }
-          }
-
-          if (type === 'response.done' || type === 'response.completed' || type === 'response.output_text.done') {
-            flushAiTyping(true);
-          }
-
-          if (!hasUserTranscriptSseRef.current && (type === 'conversation.item.input_audio_transcription.started' || type === 'input_audio_buffer.transcription.started')) {
-            handleUserTranscriptionStarted();
-          }
-
-          if (!hasUserTranscriptSseRef.current && (type === 'conversation.item.input_audio_transcription.delta' || type === 'input_audio_buffer.transcription.delta')) {
-            const delta = typeof msg.delta === 'string' ? msg.delta : '';
-            if (delta) {
-              handleUserTranscriptionDelta(delta);
-            }
-          }
-
-          if (!hasUserTranscriptSseRef.current && (type === 'conversation.item.input_audio_transcription.completed' || type === 'input_audio_buffer.transcription.completed')) {
-            const transcript = typeof msg.transcript === 'string' ? msg.transcript : '';
-            handleUserTranscriptionComplete(transcript);
-          }
-
-          if (type === 'input_audio_buffer.speech_started') {
-            handleUserTranscriptionStarted();
-          }
-
-          if (type === 'input_audio_buffer.speech_stopped') {
-            void commitAudioTurn();
-          }
-
-          if (type === 'response.error') {
-            const message = typeof msg.error === 'string' ? msg.error : 'Realtime session error';
-            setStatusMessage(null);
-            setError(message);
-          }
-        } catch (err) {
-          console.debug('[DEBUG] Failed to parse data channel message', err);
-        }
-      };
-
-      pc.ondatachannel = (ev) => {
-        const dc = ev.channel;
-        dcRef.current = dc;
-        dc.onmessage = (e) => handleDcMessage(e.data);
-        dc.onopen = () => sendDataChannelSessionUpdate();
-      };
-
-      localStream = await navigator.mediaDevices.getUserMedia({ audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true }, video: false });
-      localStream.getAudioTracks().forEach(track => pc!.addTrack(track, localStream!));
-
-      const dc = pc.createDataChannel('oai-events');
-      dcRef.current = dc;
-      dc.onmessage = (e) => handleDcMessage(e.data);
-      dc.onopen = () => sendDataChannelSessionUpdate();
-
-      const offer = await pc.createOffer({ offerToReceiveAudio: true, offerToReceiveVideo: false });
-      await pc.setLocalDescription(offer);
-
-      const resp = await fetch('/api/rt/webrtc?model=gpt-4o-realtime-preview-2024-10-01', {
-        method: 'POST',
-        body: pc.localDescription?.sdp || '',
-        cache: 'no-store',
-        headers: {
-          'Content-Type': 'application/sdp',
-          'X-LLM-Provider': activeProvider,
-          'X-LLM-Api-Key': activeApiKey,
-          'X-LLM-Model': 'gpt-4o-realtime-preview-2024-10-01',
-        },
-      });
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(`SDP exchange failed: ${resp.status} ${text}`);
-      }
-      const answerSdp = await resp.text();
-      await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
-
-      pcRef.current = pc;
-
-      if (audioRef.current) {
-        const el = audioRef.current;
-        el.onplay = () => {
-          console.log('[DEBUG] Audio started playing');
-          setIsAudioPlaying(true);
-        };
-        el.onpause = () => {
-          console.log('[DEBUG] Audio paused');
-          setIsAudioPlaying(false);
-        };
-        el.onended = () => {
-          console.log('[DEBUG] Audio ended');
-          setIsAudioPlaying(false);
-        };
-        el.onerror = (e) => {
-          console.log('[DEBUG] Audio element error (this is expected initially):', e);
-        };
-      }
-
-      setSessionDuration(0);
-      setIsConnected(true);
-      setIsSessionReady(true);
-      resetUserTranscriptionState();
-
-      console.log('[INFO] Connection successful - ready for conversation');
-    } catch (error) {
-      console.error('[ERROR] Connection failed:', error);
-      setStatusMessage(null);
-      setError(error instanceof Error ? error.message : 'Failed to connect to AI');
-      setIsConnected(false);
-      setIsSessionReady(false);
-      setIsAudioPlaying(false);
-
-      if (pc) {
-        try {
-          pc.getSenders().forEach(sender => sender.track?.stop());
-        } catch {}
-        pc.close();
-      }
-
-      if (localStream) {
-        localStream.getTracks().forEach(track => track.stop());
-      }
-
-      if (pcRef.current) {
-        try {
-          pcRef.current.getSenders().forEach(sender => sender.track?.stop());
-        } catch {}
-        pcRef.current.close();
-        pcRef.current = null;
-      }
-
-      if (dcRef.current) {
-        try { dcRef.current.close(); } catch {}
-        dcRef.current = null;
-      }
-
-      if (aiTrackRef.current) {
-        aiTrackRef.current.stop();
-        aiTrackRef.current = null;
-      }
-    } finally {
-      setIsConnecting(false);
-    }
-  };
+  }, [ensureRealtimeSession, sessionId]);
 
   const teardownRealtime = useCallback(async () => {
-    try {
-      if (mediaRecorderRef.current) {
-        mediaRecorderRef.current.stop();
-        mediaRecorderRef.current = null;
-      }
+    stopMicrophonePipeline();
 
-      if (audioEventSourceRef.current) {
-        audioEventSourceRef.current.close();
-        audioEventSourceRef.current = null;
-      }
-
-      if (userTranscriptEventSourceRef.current) {
-        userTranscriptEventSourceRef.current.close();
-        userTranscriptEventSourceRef.current = null;
-      }
-
-      if (aiTranscriptEventSourceRef.current) {
-        aiTranscriptEventSourceRef.current.close();
-        aiTranscriptEventSourceRef.current = null;
-      }
-
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.srcObject = null;
-        audioRef.current.src = '';
-      }
-
-      if (dcRef.current) {
-        try { dcRef.current.close(); } catch {}
-        dcRef.current = null;
-      }
-
-      if (pcRef.current) {
-        try {
-          pcRef.current.getSenders().forEach(sender => sender.track?.stop());
-        } catch {}
-        pcRef.current.close();
-        pcRef.current = null;
-      }
-
-      if (aiTrackRef.current) {
-        aiTrackRef.current.stop();
-        aiTrackRef.current = null;
-      }
-
-      if (audioContextRef.current) {
-        audioContextRef.current.close().catch(() => {});
-        audioContextRef.current = null;
-      }
-
-      await fetch('/api/rt/stop', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId }),
-        cache: 'no-store'
-      }).catch(() => {});
-    } catch (error) {
-      console.error('Error disconnecting:', error);
+    if (audioEventSourceRef.current) {
+      audioEventSourceRef.current.close();
+      audioEventSourceRef.current = null;
     }
-
-    if (micFlushIntervalRef.current != null) {
-      clearInterval(micFlushIntervalRef.current);
-      micFlushIntervalRef.current = null;
+    if (userTranscriptEventSourceRef.current) {
+      userTranscriptEventSourceRef.current.close();
+      userTranscriptEventSourceRef.current = null;
     }
-
-    micChunkQueueRef.current = [];
-    isUploadingRef.current = false;
-    hostAudioChunksRef.current = [];
-    aiAudioChunksRef.current = [];
-
-    aiTextBufferRef.current = '';
-    lastAiMessageIdRef.current = null;
-
-    if (aiTypingIntervalRef.current != null) {
-      clearInterval(aiTypingIntervalRef.current);
-      aiTypingIntervalRef.current = null;
+    if (aiTranscriptEventSourceRef.current) {
+      aiTranscriptEventSourceRef.current.close();
+      aiTranscriptEventSourceRef.current = null;
     }
     hasUserTranscriptSseRef.current = false;
     hasAiTranscriptSseRef.current = false;
-    const storedAudio = latestConversationRef.current?.audio;
-    const hasAudio = Boolean(storedAudio?.host || storedAudio?.ai);
-    hasCapturedAudioRef.current = hasAudio;
-    setHasCapturedAudio(hasAudio);
-    messageSequenceRef.current = 0;
-    setActiveAiMessageId(null);
-    resetUserTranscriptionState();
-  }, [resetUserTranscriptionState, sessionId]);
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.srcObject = null;
+      audioRef.current.src = "";
+    }
+
+    if (dcRef.current) {
+      try {
+        dcRef.current.close();
+      } catch (err) {
+        console.debug("[DEBUG] Failed to close data channel", err);
+      }
+      dcRef.current = null;
+    }
+
+    if (pcRef.current) {
+      try {
+        pcRef.current.getSenders().forEach((sender) => sender.track?.stop());
+      } catch (err) {
+        console.debug("[DEBUG] Failed to stop senders", err);
+      }
+      pcRef.current.close();
+      pcRef.current = null;
+    }
+
+    if (aiTrackRef.current) {
+      try {
+        aiTrackRef.current.stop();
+      } catch {}
+      aiTrackRef.current = null;
+    }
+
+    if (audioContextRef.current) {
+      audioContextRef.current.close().catch(() => {});
+      audioContextRef.current = null;
+    }
+
+    await fetch("/api/rt/stop", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId }),
+      cache: "no-store",
+    }).catch(() => {});
+
+    micChunkQueueRef.current = [];
+    hostAudioChunksRef.current = [];
+    aiAudioChunksRef.current = [];
+    isUploadingRef.current = false;
+    hasCapturedAudioRef.current = false;
+  }, [sessionId, stopMicrophonePipeline]);
 
   const buildConversationPayload = useCallback((): StoredConversation | null => {
-    if (!currentPaper || messages.length === 0) {
+    if (!currentPaper || entries.length === 0) {
       return null;
     }
 
@@ -1555,33 +932,20 @@ export default function Studio() {
     const hostAudio = encodePcm16ChunksToWav(hostAudioChunksRef.current, sampleRate);
     const aiAudio = encodePcm16ChunksToWav(aiAudioChunksRef.current, 24000);
 
-    const liveMessageId = currentUserMessageRef.current?.id;
-    const liveTranscript = userTranscriptionDisplay.trim();
-
-    const orderedMessages = sortMessages(messages).map((msg) => {
-      if (liveMessageId && msg.id === liveMessageId && liveTranscript) {
-        return {
-          ...msg,
-          content: liveTranscript,
-        };
-      }
-      return msg;
-    });
-
-    const transcript = orderedMessages.map((msg) => ({
-      id: msg.id,
-      role: msg.role,
-      content: msg.content,
-      timestamp: msg.timestamp.toISOString(),
-      speaker: msg.speaker,
-      type: msg.type,
-      order: msg.order,
+    const transcript = entries.map((entry, index) => ({
+      id: entry.id,
+      role: entry.speaker === "host" ? "user" : "expert",
+      content: entry.text.trim(),
+      timestamp: new Date(entry.startedAt).toISOString(),
+      speaker: entry.speaker === "host" ? "Host (You)" : "Dr. Sarah (AI Expert)",
+      type: "text" as const,
+      order: index,
     }));
 
-    const firstMessage = orderedMessages[0];
-    const lastMessage = orderedMessages[orderedMessages.length - 1];
-    const timelineDuration = firstMessage && lastMessage
-      ? Math.max(0, Math.round((lastMessage.timestamp.getTime() - firstMessage.timestamp.getTime()) / 1000))
+    const first = entries[0];
+    const last = entries[entries.length - 1];
+    const timelineDuration = first && last
+      ? Math.max(0, Math.round(((last.completedAt ?? last.updatedAt ?? last.startedAt) - first.startedAt) / 1000))
       : 0;
 
     const durationSeconds = Math.max(
@@ -1618,14 +982,429 @@ export default function Studio() {
       },
       durationSeconds,
     };
-  }, [currentPaper, messages, sessionDuration, sortMessages, userTranscriptionDisplay]);
+  }, [currentPaper, entries, sessionDuration]);
 
-  const handleDisconnect = async () => {
-    if (isRecording) {
-      await handleStopRecording();
+  const sendDataChannelSessionUpdate = useCallback(() => {
+    const channel = dcRef.current;
+    if (!channel || channel.readyState !== "open") {
+      return;
     }
 
     try {
+      const instructions = buildConversationInstructionsFromPaper(currentPaper);
+      channel.send(
+        JSON.stringify({
+          type: "session.update",
+          session: {
+            modalities: ["text", "audio"],
+            voice: "alloy",
+            input_audio_transcription: { model: "whisper-1" },
+            turn_detection: {
+              type: "server_vad",
+              threshold: 0.5,
+              prefix_padding_ms: 300,
+              silence_duration_ms: 800,
+            },
+            instructions,
+          },
+        }),
+      );
+    } catch (err) {
+      console.error("[ERROR] Failed to send session update over data channel:", err);
+    }
+  }, [currentPaper]);
+
+  const handleUserTranscriptionDelta = useCallback(
+    (delta: string) => {
+      appendToSegment("host", delta);
+    },
+    [appendToSegment],
+  );
+
+  const handleUserTranscriptionComplete = useCallback(
+    (transcript: string) => {
+      finalizeSegment("host", transcript);
+      void commitAudioTurn();
+    },
+    [commitAudioTurn, finalizeSegment],
+  );
+
+  const handleAiTranscriptDelta = useCallback(
+    (delta: string) => {
+      appendToSegment("ai", delta);
+    },
+    [appendToSegment],
+  );
+
+  const handleDcMessage = useCallback(
+    (data: unknown) => {
+      if (typeof data !== "string") {
+        return;
+      }
+
+      try {
+        const msg = JSON.parse(data) as Record<string, unknown>;
+        const type = typeof msg.type === "string" ? msg.type : "";
+        if (!type) {
+          return;
+        }
+
+        if (
+          !hasAiTranscriptSseRef.current &&
+          (type === "response.output_text.delta" || type === "response.text.delta" || type === "response.audio_transcript.delta")
+        ) {
+          const deltaText = typeof msg.delta === "string" ? msg.delta : "";
+          const responseText = typeof msg.text === "string" ? msg.text : "";
+          const text = deltaText || responseText;
+          if (text) {
+            handleAiTranscriptDelta(text);
+          }
+        }
+
+        if (type === "response.done" || type === "response.completed" || type === "response.output_text.done") {
+          finalizeSegment("ai");
+        }
+
+        if (
+          !hasUserTranscriptSseRef.current &&
+          (type === "conversation.item.input_audio_transcription.delta" || type === "input_audio_buffer.transcription.delta")
+        ) {
+          const delta = typeof msg.delta === "string" ? msg.delta : "";
+          if (delta) {
+            handleUserTranscriptionDelta(delta);
+          }
+        }
+
+        if (
+          !hasUserTranscriptSseRef.current &&
+          (type === "conversation.item.input_audio_transcription.completed" || type === "input_audio_buffer.transcription.completed")
+        ) {
+          const transcript = typeof msg.transcript === "string" ? msg.transcript : "";
+          handleUserTranscriptionComplete(transcript);
+        }
+
+        if (type === "conversation.item.input_audio_transcription.started" || type === "input_audio_buffer.transcription.started") {
+          ensureSegment("host");
+        }
+
+        if (type === "input_audio_buffer.speech_started") {
+          ensureSegment("host");
+        }
+
+        if (type === "input_audio_buffer.speech_stopped") {
+          void commitAudioTurn();
+        }
+
+        if (type === "response.error") {
+          const message = typeof msg.error === "string" ? msg.error : "Realtime session error";
+          setStatusMessage(null);
+          setError(message);
+        }
+      } catch (err) {
+        console.debug("[DEBUG] Failed to parse data channel message", err);
+      }
+    },
+    [commitAudioTurn, ensureSegment, finalizeSegment, handleAiTranscriptDelta, handleUserTranscriptionComplete, handleUserTranscriptionDelta],
+  );
+
+  useEffect(() => {
+    sendDataChannelSessionUpdate();
+  }, [sendDataChannelSessionUpdate]);
+
+  useEffect(() => {
+    if (phase !== "live") {
+      if (audioEventSourceRef.current) {
+        audioEventSourceRef.current.close();
+        audioEventSourceRef.current = null;
+      }
+      if (userTranscriptEventSourceRef.current) {
+        userTranscriptEventSourceRef.current.close();
+        userTranscriptEventSourceRef.current = null;
+      }
+      if (aiTranscriptEventSourceRef.current) {
+        aiTranscriptEventSourceRef.current.close();
+        aiTranscriptEventSourceRef.current = null;
+      }
+      hasUserTranscriptSseRef.current = false;
+      hasAiTranscriptSseRef.current = false;
+      return;
+    }
+
+    if (!audioEventSourceRef.current) {
+      try {
+        const source = new EventSource(`/api/rt/audio?sessionId=${sessionId}`);
+        audioEventSourceRef.current = source;
+        source.addEventListener("connected", () => {
+          console.log("[INFO] Connected to AI audio stream");
+        });
+        source.onmessage = (event) => {
+          const payload = (event.data || "").trim();
+          if (!payload || payload === "Audio stream ready") {
+            return;
+          }
+          try {
+            const binary = atob(payload);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) {
+              bytes[i] = binary.charCodeAt(i);
+            }
+            aiAudioChunksRef.current.push(bytes);
+            if (!hasCapturedAudioRef.current) {
+              hasCapturedAudioRef.current = true;
+              setHasCapturedAudio(true);
+            }
+          } catch (error) {
+            console.error("[ERROR] Failed to capture AI audio chunk", error);
+          }
+        };
+        source.addEventListener("error", (event) => {
+          console.error("[ERROR] AI audio SSE stream error", event);
+        });
+      } catch (error) {
+        console.error("[ERROR] Unable to open AI audio SSE stream", error);
+      }
+    }
+
+    if (!aiTranscriptEventSourceRef.current) {
+      try {
+        const source = new EventSource(`/api/rt/transcripts?sessionId=${sessionId}`);
+        aiTranscriptEventSourceRef.current = source;
+        hasAiTranscriptSseRef.current = true;
+        source.onmessage = (event) => {
+          const data = (event.data || "").trim();
+          if (!data || data === "Connected to AI transcript stream") {
+            return;
+          }
+          handleAiTranscriptDelta(data);
+        };
+        source.addEventListener("done", () => {
+          finalizeSegment("ai");
+        });
+        source.addEventListener("error", (event) => {
+          console.error("[ERROR] AI transcript SSE stream error", event);
+          hasAiTranscriptSseRef.current = false;
+          if (aiTranscriptEventSourceRef.current === source) {
+            source.close();
+            aiTranscriptEventSourceRef.current = null;
+          }
+        });
+      } catch (error) {
+        console.error("[ERROR] Unable to open AI transcript SSE stream", error);
+        hasAiTranscriptSseRef.current = false;
+      }
+    }
+
+    if (!userTranscriptEventSourceRef.current) {
+      try {
+        const source = new EventSource(`/api/rt/user-transcripts?sessionId=${sessionId}`);
+        userTranscriptEventSourceRef.current = source;
+        hasUserTranscriptSseRef.current = true;
+
+        const handleComplete = (event: MessageEvent) => {
+          const data = (event.data || "").trim();
+          if (!data || data === "Connected to user transcript stream") {
+            if (!data) {
+              finalizeSegment("host");
+            }
+            return;
+          }
+          handleUserTranscriptionComplete(data);
+        };
+
+        const handleDelta = (event: MessageEvent) => {
+          const data = (event.data || "").trim();
+          if (!data || data === "Connected to user transcript stream") {
+            return;
+          }
+          handleUserTranscriptionDelta(data);
+        };
+
+        source.addEventListener("complete", handleComplete);
+        source.addEventListener("delta", handleDelta);
+        source.addEventListener("error", (event) => {
+          console.error("[ERROR] User transcript SSE stream error", event);
+          hasUserTranscriptSseRef.current = false;
+          if (userTranscriptEventSourceRef.current === source) {
+            source.close();
+            userTranscriptEventSourceRef.current = null;
+          }
+        });
+      } catch (error) {
+        console.error("[ERROR] Unable to open user transcript SSE stream", error);
+        hasUserTranscriptSseRef.current = false;
+      }
+    }
+  }, [finalizeSegment, handleAiTranscriptDelta, handleUserTranscriptionComplete, handleUserTranscriptionDelta, phase, sessionId]);
+
+  const startSession = useCallback(async () => {
+    if (phase === "preparing" || phase === "live") {
+      return;
+    }
+
+    resetConversation();
+    setPhase("preparing");
+    setStatusMessage("Preparing realtime session...");
+    setError(null);
+    setSessionDuration(0);
+    hostAudioChunksRef.current = [];
+    aiAudioChunksRef.current = [];
+    latestConversationRef.current = null;
+    hasCapturedAudioRef.current = false;
+    setHasCapturedAudio(false);
+
+    let pc: RTCPeerConnection | null = null;
+    let localStream: MediaStream | null = null;
+
+    try {
+      await ensureRealtimeSession();
+
+      pc = new RTCPeerConnection({
+        iceServers: [{ urls: ["stun:stun.l.google.com:19302"] }],
+      });
+
+      pc.ontrack = (event) => {
+        const [remoteStream] = event.streams;
+        const audioElement = audioRef.current;
+        if (audioElement) {
+          audioElement.srcObject = remoteStream;
+          const playPromise = audioElement.play();
+          if (playPromise !== undefined) {
+            playPromise.catch((err) => {
+              console.warn("[WARN] Autoplay prevented for remote audio:", err);
+            });
+          }
+        } else {
+          const fallback = new Audio();
+          fallback.srcObject = remoteStream;
+          fallback.autoplay = true;
+          fallback.play().catch(() => {});
+        }
+
+        const track = event.track;
+        aiTrackRef.current = track;
+        track.onunmute = () => {
+          setIsAiSpeaking(true);
+        };
+        track.onmute = () => {
+          setIsAiSpeaking(false);
+        };
+        track.onended = () => {
+          setIsAiSpeaking(false);
+        };
+      };
+
+      pc.ondatachannel = (ev) => {
+        const dc = ev.channel;
+        dcRef.current = dc;
+        dc.onmessage = (e) => handleDcMessage(e.data);
+        dc.onopen = () => sendDataChannelSessionUpdate();
+      };
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+        video: false,
+      });
+      localStream = stream;
+      localStream.getAudioTracks().forEach((track) => pc!.addTrack(track, localStream!));
+
+      const dc = pc.createDataChannel("oai-events");
+      dcRef.current = dc;
+      dc.onmessage = (e) => handleDcMessage(e.data);
+      dc.onopen = () => sendDataChannelSessionUpdate();
+
+      const offer = await pc.createOffer({ offerToReceiveAudio: true, offerToReceiveVideo: false });
+      await pc.setLocalDescription(offer);
+
+      const resp = await fetch("/api/rt/webrtc?model=gpt-4o-realtime-preview-2024-10-01", {
+        method: "POST",
+        body: pc.localDescription?.sdp || "",
+        cache: "no-store",
+        headers: {
+          "Content-Type": "application/sdp",
+          "X-LLM-Provider": activeProvider,
+          "X-LLM-Api-Key": activeApiKey,
+          "X-LLM-Model": "gpt-4o-realtime-preview-2024-10-01",
+        },
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(`SDP exchange failed: ${resp.status} ${text}`);
+      }
+      const answerSdp = await resp.text();
+      await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+
+      pcRef.current = pc;
+
+      if (audioRef.current) {
+        const el = audioRef.current;
+        el.onplay = () => {
+          setIsAudioPlaying(true);
+        };
+        el.onpause = () => {
+          setIsAudioPlaying(false);
+        };
+        el.onended = () => {
+          setIsAudioPlaying(false);
+        };
+      }
+
+      setPhase("live");
+      setStatusMessage("Live recording started.");
+
+      const micStarted = await startMicrophonePipeline();
+      if (!micStarted) {
+        throw new Error("Microphone access required to record the conversation.");
+      }
+
+      sendDataChannelSessionUpdate();
+    } catch (err) {
+      console.error("[ERROR] Connection failed:", err);
+      setStatusMessage(null);
+      setError(err instanceof Error ? err.message : "Failed to connect to AI");
+      if (pc) {
+        try {
+          pc.getSenders().forEach((sender) => sender.track?.stop());
+        } catch {}
+        pc.close();
+      }
+      if (localStream) {
+        localStream.getTracks().forEach((track) => track.stop());
+      }
+      if (pcRef.current) {
+        try {
+          pcRef.current.getSenders().forEach((sender) => sender.track?.stop());
+        } catch {}
+        pcRef.current.close();
+        pcRef.current = null;
+      }
+      if (dcRef.current) {
+        try {
+          dcRef.current.close();
+        } catch {}
+        dcRef.current = null;
+      }
+      if (aiTrackRef.current) {
+        try {
+          aiTrackRef.current.stop();
+        } catch {}
+        aiTrackRef.current = null;
+      }
+      setPhase("idle");
+      setIsRecording(false);
+    }
+  }, [activeApiKey, activeProvider, ensureRealtimeSession, handleDcMessage, phase, resetConversation, sendDataChannelSessionUpdate, startMicrophonePipeline]);
+
+  const stopSession = useCallback(async () => {
+    if (phase === "idle" || phase === "stopping") {
+      return;
+    }
+
+    setPhase("stopping");
+    setStatusMessage("Wrapping up session...");
+    setError(null);
+
+    try {
+      stopMicrophonePipeline();
       const payload = buildConversationPayload();
       if (payload) {
         latestConversationRef.current = payload;
@@ -1633,81 +1412,83 @@ export default function Studio() {
         const hasAudio = Boolean(payload.audio.host || payload.audio.ai);
         hasCapturedAudioRef.current = hasAudio;
         setHasCapturedAudio(hasAudio);
-        setStatusMessage('Conversation saved for the Video Studio.');
+        setStatusMessage("Conversation saved for the Video Studio.");
       } else {
         latestConversationRef.current = null;
         hasCapturedAudioRef.current = false;
         setHasCapturedAudio(false);
         setStatusMessage(null);
       }
-    } catch (storageError) {
-      console.error('Failed to persist conversation for Video Studio', storageError);
+    } catch (error) {
+      console.error("Failed to persist conversation", error);
       setStatusMessage(null);
     }
 
     await teardownRealtime();
 
-    setIsConnecting(false);
-    setIsConnected(false);
-    setIsSessionReady(false);
+    setPhase("idle");
     setIsRecording(false);
-    setSessionDuration(0);
-    setMessages([]);
-    setError(null);
-    resetUserTranscriptionState();
-    setActiveAiMessageId(null);
     setIsAudioPlaying(false);
-  };
+  }, [buildConversationPayload, phase, stopMicrophonePipeline, teardownRealtime]);
 
-  const handleSendToVideoStudio = async () => {
+  useEffect(() => {
+    return () => {
+      stopSession().catch(() => {});
+    };
+  }, [stopSession]);
+
+  const handleSendToVideoStudio = useCallback(async () => {
     try {
-      if (isRecording) {
-        await handleStopRecording();
-      }
-
-      const payload = buildConversationPayload();
+      const payload = buildConversationPayload() ?? latestConversationRef.current;
       if (!payload) {
-        setError('Capture a conversation before sending it to the Video Studio.');
+        setError("Capture a conversation before sending it to the Video Studio.");
         setStatusMessage(null);
         return;
       }
-
       latestConversationRef.current = payload;
       saveConversationToSession(payload);
       const hasAudio = Boolean(payload.audio.host || payload.audio.ai);
       hasCapturedAudioRef.current = hasAudio;
       setHasCapturedAudio(hasAudio);
       setError(null);
-      setStatusMessage('Conversation handed off to the Video Studio.');
-      router.push('/video-studio');
+      setStatusMessage("Conversation handed off to the Video Studio.");
+      router.push("/video-studio");
     } catch (error) {
-      console.error('[ERROR] Failed to prepare conversation for Video Studio', error);
+      console.error("[ERROR] Failed to prepare conversation for Video Studio", error);
       setStatusMessage(null);
-      setError(error instanceof Error ? error.message : 'Failed to prepare conversation for Video Studio');
+      setError(error instanceof Error ? error.message : "Failed to prepare conversation for Video Studio");
     }
-  };
+  }, [buildConversationPayload, router]);
 
-  useEffect(() => {
-    return () => {
-      teardownRealtime().catch(() => {});
-    };
-  }, [teardownRealtime]);
+  const handleExportTranscript = useCallback(() => {
+    if (entries.length === 0) {
+      setError("Record a conversation before exporting the transcript.");
+      setStatusMessage(null);
+      return;
+    }
+    const transcriptText = entries
+      .map((entry) => {
+        const timestamp = new Date(entry.startedAt).toLocaleTimeString("en-US", {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false,
+        });
+        const speakerLabel = entry.speaker === "host" ? "Host (You)" : "Dr. Sarah";
+        return `[${timestamp}] ${speakerLabel}: ${entry.text}`;
+      })
+      .join("\n\n");
 
-  const handleExportTranscript = () => {
-    const transcriptText = messages.map((msg: ConversationMessage) =>
-      `[${msg.timestamp.toLocaleTimeString()}] ${msg.speaker || (msg.role === 'user' ? 'You' : msg.role)}: ${msg.content}`
-    ).join('\n\n');
-
-    const blob = new Blob([transcriptText], { type: 'text/plain' });
+    const blob = new Blob([transcriptText], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'podcast-transcript.txt';
+    a.download = "podcast-transcript.txt";
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  };
+  }, [entries]);
 
   const handleDownloadAudio = useCallback(async () => {
     try {
@@ -1715,9 +1496,8 @@ export default function Studio() {
       if (!payload) {
         payload = latestConversationRef.current;
       }
-
       if (!payload || (!payload.audio.host && !payload.audio.ai)) {
-        setError('Capture a conversation with audio before downloading.');
+        setError("Capture a conversation with audio before downloading.");
         setStatusMessage(null);
         return;
       }
@@ -1728,45 +1508,49 @@ export default function Studio() {
 
       if (payload.audio.host) {
         const hostBytes = base64ToUint8Array(payload.audio.host.base64);
-        files.push({ name: 'host-track.wav', data: hostBytes });
+        files.push({ name: "host-track.wav", data: hostBytes });
       }
-
       if (payload.audio.ai) {
         const aiBytes = base64ToUint8Array(payload.audio.ai.base64);
-        files.push({ name: 'ai-track.wav', data: aiBytes });
+        files.push({ name: "ai-track.wav", data: aiBytes });
       }
 
       const transcriptText = payload.transcript
         .map((entry) => {
-          const timestamp = new Date(entry.timestamp).toLocaleTimeString('en-US', {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
+          const timestamp = new Date(entry.timestamp).toLocaleTimeString("en-US", {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
             hour12: false,
           });
-          const speakerLabel = entry.speaker || (entry.role === 'user' ? 'Host' : 'Dr. Sarah');
+          const speakerLabel = entry.speaker || (entry.role === "user" ? "Host" : "Dr. Sarah");
           return `[${timestamp}] ${speakerLabel}: ${entry.content}`;
         })
-        .join('\n\n');
+        .join("\n\n");
 
       const encoder = new TextEncoder();
-      files.push({ name: 'transcript.txt', data: encoder.encode(transcriptText) });
+      files.push({ name: "transcript.txt", data: encoder.encode(transcriptText) });
       files.push({
-        name: 'metadata.json',
-        data: encoder.encode(JSON.stringify({
-          paper: payload.paper,
-          durationSeconds: payload.durationSeconds,
-          createdAt: payload.createdAt,
-        }, null, 2)),
+        name: "metadata.json",
+        data: encoder.encode(
+          JSON.stringify(
+            {
+              paper: payload.paper,
+              durationSeconds: payload.durationSeconds,
+              createdAt: payload.createdAt,
+            },
+            null,
+            2,
+          ),
+        ),
       });
 
       const archiveBytes = createZipArchive(files);
-      // Ensure we pass a proper ArrayBuffer (not ArrayBufferLike) to Blob
       const buffer = new ArrayBuffer(archiveBytes.byteLength);
       new Uint8Array(buffer).set(archiveBytes);
-      const blob = new Blob([buffer], { type: 'application/zip' });
+      const blob = new Blob([buffer], { type: "application/zip" });
       const downloadUrl = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
+      const anchor = document.createElement("a");
       anchor.href = downloadUrl;
       anchor.download = `podcast-session-${sessionId}.zip`;
       document.body.appendChild(anchor);
@@ -1775,75 +1559,78 @@ export default function Studio() {
       URL.revokeObjectURL(downloadUrl);
 
       setError(null);
-      setStatusMessage('Audio bundle downloaded successfully.');
+      setStatusMessage("Audio bundle downloaded successfully.");
     } catch (error) {
-      console.error('[ERROR] Failed to export audio bundle', error);
+      console.error("[ERROR] Failed to export audio bundle", error);
       setStatusMessage(null);
-      setError(error instanceof Error ? error.message : 'Failed to download audio bundle');
+      setError(error instanceof Error ? error.message : "Failed to download audio bundle");
     }
   }, [base64ToUint8Array, buildConversationPayload, sessionId]);
 
+  const headerStatus = useMemo(() => {
+    switch (phase) {
+      case "preparing":
+        return { label: "CONNECTING", color: "yellow", active: false };
+      case "live":
+        return { label: "LIVE", color: "red", active: true };
+      case "stopping":
+        return { label: "SAVING", color: "yellow", active: false };
+      default:
+        return { label: "IDLE", color: "gray", active: false };
+    }
+  }, [phase]);
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-purple-50/30">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-purple-50/40">
       <div className="flex">
         <Sidebar
           collapsed={collapsed}
           onToggleCollapse={toggleCollapsed}
-          isLiveRecording={isRecording}
+          isLiveRecording={phase === "live"}
         />
-        
-        {/* Main Content */}
+
         <div className="flex-1">
           <Header
             title="Audio Studio"
-            description="Generate audio conversations between you and AI experts"
-            status={{
-              label: !isConnected ? 'DISCONNECTED' : !isSessionReady ? 'CONNECTING' : isRecording ? 'LIVE' : 'READY',
-              color: !isConnected || !isSessionReady ? 'yellow' : isRecording ? 'red' : 'green',
-              active: isRecording
-            }}
-            timer={{
-              duration: sessionDuration,
-              format: formatTime
-            }}
+            description="Capture a realtime podcast between you and an AI expert."
+            status={headerStatus}
+            timer={{ duration: sessionDuration, format: formatTime }}
           />
 
           <main className="p-6 space-y-6">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              {/* Paper Info */}
-              <div className="lg:col-span-1 space-y-6">
-                <Card className="animate-fade-in">
+            <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+              <div className="space-y-6">
+                <Card className="shadow-sm border border-slate-200/70 backdrop-blur-sm bg-white/80">
                   <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <BookOpen className="w-5 h-5 text-purple-600" />
-                      <span>Current Paper</span>
+                    <CardTitle className="flex items-center gap-2 text-slate-800">
+                      <FileText className="w-5 h-5 text-purple-500" />
+                      Current Paper
                     </CardTitle>
                   </CardHeader>
-                  <CardContent className="space-y-4">
+                  <CardContent className="space-y-4 text-sm text-slate-600">
                     {paperLoadError ? (
-                      <div className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg p-3">
+                      <div className="rounded-lg border border-red-200 bg-red-50/80 p-3 text-red-600">
                         {paperLoadError}
                       </div>
                     ) : currentPaper ? (
-                      <>
-                        <div className="space-y-3">
-                          <h3 className="font-semibold text-gray-900 mb-1 line-clamp-2 leading-tight">
+                      <div className="space-y-4">
+                        <div className="space-y-2">
+                          <h3 className="font-semibold text-slate-900 leading-tight">
                             {currentPaper.title}
                           </h3>
-                          <div className="text-xs text-gray-500 uppercase tracking-wide">
+                          <p className="text-xs uppercase tracking-wide text-slate-500">
                             Published {currentPaper.formattedPublishedDate ?? "(date unavailable)"}
-                          </div>
-                          <p className="text-sm text-gray-600">
+                          </p>
+                          <p className="text-sm text-slate-600">
                             {currentPaper.primaryAuthor
                               ? `${currentPaper.primaryAuthor}${currentPaper.hasAdditionalAuthors ? " et al." : ""}`
                               : currentPaper.authors}
                           </p>
-                          <p className="text-sm text-gray-500 line-clamp-4 leading-relaxed">
-                            {currentPaper.abstract}
-                          </p>
                         </div>
-
-                        <div className="space-y-2">
+                        <p className="leading-relaxed text-slate-600/90">
+                          {currentPaper.abstract}
+                        </p>
+                        <div className="flex flex-col gap-2">
                           {currentPaper.arxiv_url ? (
                             <Button asChild variant="outline" className="w-full">
                               <a
@@ -1851,348 +1638,205 @@ export default function Studio() {
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >
-                                <FileText className="w-4 h-4 mr-2" />
-                                View Full Paper
+                                <FileText className="mr-2 h-4 w-4" />
+                                View on arXiv
                               </a>
                             </Button>
                           ) : (
                             <Button variant="outline" className="w-full" disabled>
-                              <FileText className="w-4 h-4 mr-2" />
-                              View Full Paper
+                              <FileText className="mr-2 h-4 w-4" />
+                              View on arXiv
                             </Button>
                           )}
-                          <Button variant="outline" className="w-full" disabled>
-                            <Brain className="w-4 h-4 mr-2" />
-                            AI Summary
-                          </Button>
                         </div>
-                      </>
+                      </div>
                     ) : (
-                      <div className="text-sm text-gray-600 space-y-2">
-                        <p className="font-medium text-gray-700">
-                          Select a research paper from the Research Hub to populate this view.
+                      <div className="space-y-2 text-slate-600">
+                        <p className="font-medium text-slate-800">
+                          Select a paper from the Research Hub to pre-load conversation context.
                         </p>
-                        <p className="text-gray-500">
-                          Your selected paper details will appear here automatically once you start the Audio Studio from a research card.
+                        <p className="text-sm text-slate-500">
+                          Paper details populate automatically when you start the studio from a selected card.
                         </p>
                       </div>
                     )}
                   </CardContent>
                 </Card>
 
-                {/* Recording Controls */}
-                <Card className="animate-slide-up">
+                <Card className="shadow-sm border border-slate-200/70 backdrop-blur-sm bg-white/80">
                   <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
+                    <CardTitle className="flex items-center gap-2 text-slate-800">
                       <Mic className="w-5 h-5 text-red-500" />
-                      <span>Recording Controls</span>
+                      Session Controls
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     {error && (
-                      <div className="text-red-500 text-sm mb-2 p-2 bg-red-50 rounded">
-                        Error: {error}
+                      <div className="rounded-lg border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+                        {error}
                       </div>
                     )}
-
                     {!error && statusMessage && (
-                      <div className="text-green-600 text-sm mb-2 p-2 bg-green-50 border border-green-200 rounded">
+                      <div className="rounded-lg border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
                         {statusMessage}
                       </div>
                     )}
 
-                    <div className="flex space-x-2">
-                      {!isConnected ? (
-                        <Button
-                          onClick={handleConnect}
-                          variant="default"
-                          size="lg"
-                          className="flex-1"
-                          disabled={isConnecting}
-                        >
-                          <Brain className="w-4 h-4 mr-2" />
-                          {isConnecting ? 'Connecting...' : 'Connect to AI'}
-                        </Button>
-                      ) : !isRecording ? (
+                    <div className="flex flex-col gap-2">
                       <Button
-                        onClick={handleStartRecording}
-                        disabled={!isConnected || !isSessionReady}
-                        variant="destructive"
+                        onClick={startSession}
+                        disabled={phase === "preparing" || phase === "live"}
                         size="lg"
-                        className="flex-1"
+                        className="w-full justify-center"
                       >
-                        <Mic className="w-4 h-4 mr-2" />
-                        {hasCapturedAudio ? 'Resume Voice Recording' : 'Start Voice Recording'}
+                        <Mic className="mr-2 h-4 w-4" />
+                        {phase === "preparing" ? "Connecting…" : "Start Live Session"}
                       </Button>
-                      ) : (
-                        <Button 
-                          onClick={handleStopRecording}
-                          variant="outline"
-                          size="lg"
-                          className="flex-1"
-                        >
-                          <MicOff className="w-4 h-4 mr-2" />
-                          Stop Recording
-                        </Button>
-                      )}
-                    </div>
-                    
-                    <div className="flex space-x-2">
-                      <input
-                        type="text"
-                        value={textInput}
-                        onChange={(e) => setTextInput(e.target.value)}
-                        placeholder="Type your message..."
-                        className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && !e.shiftKey) {
-                            e.preventDefault();
-                            handleSendText();
-                          }
-                        }}
-                      />
                       <Button
-                        onClick={handleSendText}
-                        disabled={!textInput.trim() || !isConnected || !isSessionReady}
+                        onClick={stopSession}
+                        disabled={phase !== "live"}
+                        variant="outline"
                         size="lg"
+                        className="w-full justify-center"
                       >
-                        <Send className="w-4 h-4" />
+                        <MicOff className="mr-2 h-4 w-4" />
+                        End Session
                       </Button>
                     </div>
-                    
-                    <div className="space-y-2">
-                      <Button variant="ghost" className="w-full justify-start" onClick={handleExportTranscript}>
-                        <FileText className="w-4 h-4 mr-2" />
+
+                    <div className="grid grid-cols-1 gap-2">
+                      <Button variant="ghost" className="justify-start" onClick={handleExportTranscript}>
+                        <FileText className="mr-2 h-4 w-4" />
                         Export Transcript
                       </Button>
-                      <Button variant="ghost" className="w-full justify-start" onClick={handleSendToVideoStudio}>
-                        <Video className="w-4 h-4 mr-2" />
+                      <Button variant="ghost" className="justify-start" onClick={handleDownloadAudio} disabled={!hasCapturedAudio}>
+                        <Download className="mr-2 h-4 w-4" />
+                        Download Audio Bundle
+                      </Button>
+                      <Button variant="ghost" className="justify-start" onClick={handleSendToVideoStudio}>
+                        <Video className="mr-2 h-4 w-4" />
                         Send to Video Studio
                       </Button>
-                      <Button variant="ghost" className="w-full justify-start" onClick={handleDisconnect}>
-                        <RotateCcw className="w-4 h-4 mr-2" />
-                        Disconnect Session
-                      </Button>
+                    </div>
+
+                    <div className="rounded-lg border border-slate-200 bg-slate-50/80 p-3 text-xs text-slate-500 space-y-1">
+                      <p className="flex items-center gap-2 font-medium text-slate-700">
+                        <Radio className="h-3.5 w-3.5 text-emerald-500" />
+                        Live session tips
+                      </p>
+                      <ul className="list-disc pl-5 space-y-1">
+                        <li>Speak naturally and pause briefly when finished—turn detection is automatic.</li>
+                        <li>The feed scrolls to the latest utterance so you never lose the live moment.</li>
+                        <li>Download or hand off the conversation after ending the session.</li>
+                      </ul>
                     </div>
                   </CardContent>
                 </Card>
               </div>
 
-              {/* Live Transcript */}
-              <div className="lg:col-span-2">
-                <Card className="h-[600px] flex flex-col overflow-hidden animate-scale-in border border-gray-200 shadow-sm">
-                  <CardHeader className="flex-shrink-0 border-b border-gray-100 bg-gray-50/30">
+              <div className="xl:col-span-2">
+                <Card className="h-[640px] flex flex-col overflow-hidden shadow-lg border border-slate-200/70 backdrop-blur bg-white/70">
+                  <CardHeader className="border-b border-slate-200/60 bg-white/70">
                     <div className="flex items-center justify-between">
-                      <CardTitle className="flex items-center space-x-2">
-                        <FileText className="w-5 h-5 text-green-600" />
-                        <span>Live Transcript</span>
+                      <CardTitle className="flex items-center gap-2 text-slate-800">
+                        <Sparkles className="h-5 w-5 text-indigo-500" />
+                        Live Conversation Feed
                       </CardTitle>
-                      <div className="flex items-center space-x-4">
-                        <div className="flex items-center space-x-3 text-xs">
-                          <div className="flex items-center space-x-1 text-gray-500">
-                            <div className="w-2 h-2 rounded-full bg-purple-500 shadow-sm"></div>
-                            <span>Host (You)</span>
-                          </div>
-                          <div className="flex items-center space-x-1 text-gray-500">
-                            <div className="w-2 h-2 rounded-full bg-blue-500 shadow-sm"></div>
-                            <span>Dr. Sarah (AI Expert)</span>
-                          </div>
+                      <div className="flex items-center gap-4 text-xs text-slate-500">
+                        <div className="flex items-center gap-1">
+                          <span className="inline-flex h-2 w-2 rounded-full bg-purple-500" /> Host
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <span className="inline-flex h-2 w-2 rounded-full bg-blue-500" /> Dr. Sarah
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Volume2 className="h-3 w-3" />
+                          {phase === "live"
+                            ? isAudioPlaying
+                              ? "AI audio streaming"
+                              : "Waiting for response"
+                            : "Session idle"}
                         </div>
                       </div>
                     </div>
                   </CardHeader>
-                
-                  <CardContent className="flex-1 flex flex-col p-0 bg-white">
+
+                  <CardContent className="flex-1 flex flex-col p-0">
                     <ScrollArea ref={transcriptScrollRef} className="flex-1 px-6 py-4">
                       <div className="space-y-4">
-                        {messages.length === 0 && !isRecording && (
-                          <div className="text-center text-gray-500 py-8">
-                            <Brain className="w-16 h-16 mx-auto mb-4 opacity-50" />
-                            <div className="space-y-2">
-                              {!isSessionReady ? (
-                                <p>Click &ldquo;Connect to AI&rdquo; to begin your conversation</p>
-                              ) : (
-                                <>
-                                  <p className="font-medium">Ready for podcast conversation!</p>
-                                  <p className="text-sm">• Click &ldquo;Start Voice Recording&rdquo; and speak</p>
-                                  <p className="text-sm">• Wait 1 second of silence after speaking</p>
-                                  <p className="text-sm">• Dr. Sarah will respond with voice and text</p>
-                                  <p className="text-sm">• Or type a message to start</p>
-                                </>
-                              )}
-                            </div>
+                        {entries.length === 0 && phase !== "live" && (
+                          <div className="text-center text-slate-500 py-16 space-y-3">
+                            <Brain className="mx-auto h-12 w-12 opacity-50" />
+                            <p className="font-medium text-slate-700">Ready to capture your next conversation.</p>
+                            <p className="text-sm text-slate-500">Start the session and speak naturally—the transcript will appear instantly.</p>
                           </div>
                         )}
-                        
-                        {messages.map((entry: ConversationMessage) => {
-                          const isUser = entry.role === "user";
-                          
-                          const avatarStyles = isUser 
-                            ? "bg-purple-100 border-purple-200 text-purple-600"
-                            : "bg-blue-100 border-blue-200 text-blue-600";
-                            
-                          const messageStyles = isUser
-                            ? "bg-gradient-to-r from-purple-50 to-purple-50/70 border-purple-200 text-gray-800"
-                            : "bg-gradient-to-r from-blue-50 to-blue-50/70 border-blue-200 text-gray-800";
-                            
-                          const displayName = entry.speaker || (isUser ? "You" : "Dr. Sarah");
-                          
+
+                        {entries.map((entry) => {
+                          const isHost = entry.speaker === "host";
+                          const bubbleClass = isHost
+                            ? "bg-gradient-to-r from-purple-50 to-purple-100/60 border border-purple-200/70"
+                            : "bg-gradient-to-r from-blue-50 to-blue-100/60 border border-blue-200/70";
+                          const avatarClass = isHost
+                            ? "bg-purple-100 text-purple-600 border border-purple-200"
+                            : "bg-blue-100 text-blue-600 border border-blue-200";
+                          const speakerLabel = isHost ? "Host (You)" : "Dr. Sarah";
+                          const timestamp = new Date(entry.startedAt).toLocaleTimeString("en-US", {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                            second: "2-digit",
+                            hour12: false,
+                          });
+
                           return (
-                            <div
-                              key={entry.id}
-                              className="flex items-start space-x-3 animate-fade-in"
-                            >
-                              <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 shadow-sm border ${avatarStyles}`}>
-                                {isUser ? (
-                                  <Headphones className="w-5 h-5" />
-                                ) : (
-                                  <Brain className="w-5 h-5" />
-                                )}
+                            <div key={entry.id} className="flex items-start gap-3">
+                              <div className={`flex h-11 w-11 items-center justify-center rounded-xl shadow-sm ${avatarClass}`}>
+                                {isHost ? <Headphones className="h-5 w-5" /> : <Sparkles className="h-5 w-5" />}
                               </div>
-                              <div className="flex-1 min-w-0">
-                                <div className="flex items-center space-x-2 mb-2">
-                                  <span className="text-sm font-semibold text-gray-900">
-                                    {displayName}
-                                  </span>
-                                  <span className="text-xs text-gray-500 font-mono bg-gray-100 border border-gray-200 px-2 py-1 rounded-md shadow-sm">
-                                    {entry.timestamp.toLocaleTimeString('en-US', {
-                                      hour: '2-digit', 
-                                      minute: '2-digit', 
-                                      second: '2-digit', 
-                                      hour12: false
-                                    })}
+                              <div className="flex-1 min-w-0 space-y-2">
+                                <div className="flex items-center gap-2">
+                                  <span className="text-sm font-semibold text-slate-800">{speakerLabel}</span>
+                                  <span className="text-xs font-mono text-slate-500 bg-white/70 border border-slate-200 px-2 py-0.5 rounded-md">
+                                    {timestamp}
                                   </span>
                                 </div>
-                                <div className={`p-4 rounded-xl border-2 shadow-sm transition-all hover:shadow-md ${messageStyles}`}>
-                                  <p className="text-sm leading-relaxed">
-                                    {entry.content}
-                                    {entry.id === activeUserMessageId && (
-                                      <span className="inline-block w-2 h-4 bg-purple-500/70 ml-1 animate-pulse rounded-sm align-middle" />
-                                    )}
-                                    {entry.id === activeAiMessageId && (
-                                      <span className="inline-block w-2 h-4 bg-blue-500/70 ml-1 animate-pulse rounded-sm align-middle" />
-                                    )}
-                                  </p>
+                                <div className={`rounded-2xl px-4 py-3 text-sm text-slate-800 shadow-sm ${bubbleClass}`}>
+                                  <span>{entry.text || (entry.status === "streaming" ? "…" : "")}</span>
+                                  {entry.status === "streaming" && (
+                                    <span className="ml-1 inline-block h-3 w-1.5 animate-pulse rounded bg-slate-500/70 align-middle" />
+                                  )}
                                 </div>
                               </div>
                             </div>
                           );
                         })}
 
-                        {/* Live indicator when recording */}
-                        {isRecording && (
-                          <div className="flex items-center space-x-3 opacity-80 animate-pulse border border-green-200 bg-green-50/50 p-3 rounded-lg">
-                            <div className="w-10 h-10 rounded-xl bg-green-100 border border-green-200 flex items-center justify-center shadow-sm">
-                              <Mic className="w-5 h-5 text-green-600" />
-                            </div>
-                            <div className="flex-1">
-                              <div className="text-sm font-medium text-green-800">
-                                Recording...
-                              </div>
-                              <div className="text-xs text-green-600">
-                                Ready for new audio implementation
-                              </div>
-                            </div>
-                            <div className="flex space-x-1">
-                              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-                              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" style={{ animationDelay: '0.2s' }}></div>
-                              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" style={{ animationDelay: '0.4s' }}></div>
-                            </div>
+                        {phase === "live" && (
+                          <div className="flex items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-700 shadow-sm">
+                            <Radio className="h-4 w-4" />
+                            <span>
+                              {isHostSpeaking
+                                ? "Recording your voice…"
+                                : isAiSpeaking
+                                  ? "Dr. Sarah is responding…"
+                                  : "Session is listening for the next speaker."}
+                            </span>
                           </div>
                         )}
-                        
-                        {/* Live transcription when user is speaking */}
-                        {isUserSpeaking && (
-                          <div className="flex items-start space-x-3 animate-fade-in">
-                            <div className="w-10 h-10 rounded-xl bg-yellow-100 border border-yellow-200 flex items-center justify-center flex-shrink-0 shadow-sm">
-                              <Mic className="w-5 h-5 text-yellow-600" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center space-x-2 mb-2">
-                                <span className="text-sm font-semibold text-gray-900">
-                                  You (Speaking...)
-                                </span>
-                                <span className="text-xs text-yellow-600 font-mono bg-yellow-50 border border-yellow-200 px-2 py-1 rounded-md">
-                                  LIVE TRANSCRIPT
-                                </span>
-                              </div>
-                              <div className="p-4 rounded-xl border-2 border-yellow-200 bg-gradient-to-r from-yellow-50 to-yellow-50/70 shadow-sm">
-                                <p className="text-sm leading-relaxed text-gray-800">
-                                  {userTranscriptionDisplay || <span className="text-xs text-yellow-500 uppercase tracking-wide">Listening...</span>}
-                                  <span className="inline-block w-2 h-4 bg-yellow-500 ml-1 animate-pulse"></span>
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        )}
-                        <div ref={transcriptEndRef} />
                       </div>
                     </ScrollArea>
-                  
-                    {/* Audio Controls */}
-                    <div className="px-6 py-4 border-t border-gray-200 bg-gradient-to-r from-gray-50 to-gray-50/80 flex-shrink-0">
-                      {/* Hidden audio element for streaming */}
-                      <audio 
-                        ref={audioRef} 
-                        className="hidden"
-                        onError={(e) => console.log('[DEBUG] Audio element error (expected initially):', e)}
-                      />
-                      
-                      <div className="flex items-center space-x-4 mb-3">
-                        <div className="flex items-center space-x-2">
-                          <Button 
-                            size="sm" 
-                            variant="outline" 
-                            className="border-gray-300 hover:border-purple-400 hover:bg-purple-50"
-                            onClick={() => {
-                              if (isAudioPlaying && audioRef.current) {
-                                audioRef.current.pause();
-                              } else {
-                                console.log('[INFO] Audio playback will happen automatically when AI responds');
-                              }
-                            }}
-                            disabled={!isConnected}
-                          >
-                            {isAudioPlaying ? (
-                              <Pause className="w-4 h-4 mr-2" />
-                            ) : (
-                              <Play className="w-4 h-4 mr-2" />
-                            )}
-                            {isAudioPlaying ? 'Pause' : 'Audio'} Ready
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="border-gray-300 hover:border-green-400 hover:bg-green-50"
-                            onClick={handleDownloadAudio}
-                            disabled={!hasCapturedAudio}
-                          >
-                            <Download className="w-4 h-4 mr-2" />
-                            Download Audio Bundle
-                          </Button>
-                        </div>
-                        <div className="flex-1 bg-gray-200 rounded-full h-2 shadow-inner">
-                          <div 
-                            className={`h-2 rounded-full transition-all duration-300 shadow-sm ${
-                              isAudioPlaying ? 'bg-gradient-to-r from-purple-500 to-blue-500 animate-pulse' : 'bg-gray-400'
-                            }`}
-                            style={{ width: isAudioPlaying ? '60%' : '0%' }}
-                          ></div>
-                        </div>
-                        <div className="text-sm text-gray-600 font-mono bg-white px-3 py-1 rounded-md border border-gray-200 shadow-sm">
-                          {formatTime(sessionDuration)}
-                        </div>
+
+                    <div className="border-t border-slate-200/70 bg-white/70 px-6 py-4 flex items-center justify-between text-xs text-slate-500">
+                      <div className="flex items-center gap-2">
+                        <Volume2 className="h-4 w-4" />
+                        {phase === "live"
+                          ? isRecording
+                            ? "Microphone streaming in realtime"
+                            : "Microphone idle"
+                          : "Session idle"}
                       </div>
-                      <div className="flex items-center space-x-2 text-xs text-gray-500">
-                        <Volume2 className="w-3 h-3" />
-                        <span>
-                          {!isConnected 
-                            ? 'Connect to AI to start audio streaming' 
-                            : isAudioPlaying 
-                              ? 'AI audio playing...' 
-                              : 'Ready for conversation'
-                          }
-                        </span>
+                      <div className="font-mono text-sm text-slate-600">
+                        {formatTime(sessionDuration)}
                       </div>
                     </div>
                   </CardContent>
@@ -2204,4 +1848,7 @@ export default function Studio() {
       </div>
     </div>
   );
-}
+};
+
+export default StudioPage;
+

--- a/podcast-studio/src/hooks/useRealtimeConversation.ts
+++ b/podcast-studio/src/hooks/useRealtimeConversation.ts
@@ -130,10 +130,10 @@ export const useRealtimeConversation = () => {
         if (!response.ok) {
           throw new Error('Backend server not responding');
         }
-      } catch (fetchError) {
-        setState(prev => ({ 
-          ...prev, 
-          error: 'Backend server is not running. Please check your backend configuration.' 
+      } catch {
+        setState(prev => ({
+          ...prev,
+          error: 'Backend server is not running. Please check your backend configuration.'
         }));
         return;
       }


### PR DESCRIPTION
## Summary
- rebuild the Audio Studio page around a unified conversation state machine with per-speaker typing buffers, auto-scroll, and session phase tracking
- streamline the live session lifecycle so connecting starts WebRTC, SSE feeds, and microphone streaming automatically, while persisting and exporting captured conversations
- refresh the Audio Studio layout with a focused live feed, start/stop controls, and context cards, and tighten realtime API routes to use typed error handling and deterministic cleanup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd18d36bf8832e934064e4ad5f594e