### PR TITLE
Fix realtime auth flow and harden API key handling

### DIFF
--- a/podcast-studio/src/app/api/test-openai/route.ts
+++ b/podcast-studio/src/app/api/test-openai/route.ts
@@ -16,8 +16,7 @@ export async function GET() {
       }, { status: 500 });
     }
     
-    console.log('[TEST] API key found, length:', apiKey.length);
-    console.log('[TEST] API key starts with:', apiKey.substring(0, 7));
+    console.log('[TEST] API key located in environment variables');
     
     // Test a simple OpenAI API call first
     const response = await fetch('https://api.openai.com/v1/models', {
@@ -31,12 +30,12 @@ export async function GET() {
     
     if (!response.ok) {
       const errorData = await response.text();
-      console.log('[TEST] Models API error:', errorData);
-      return NextResponse.json({ 
+      const snippet = errorData.slice(0, 200);
+      console.log('[TEST] Models API error snippet:', snippet);
+      return NextResponse.json({
         error: 'OpenAI API key validation failed',
         status: response.status,
-        details: errorData,
-        hasKey: true 
+        hasKey: true
       }, { status: 500 });
     }
     
@@ -51,7 +50,6 @@ export async function GET() {
     return NextResponse.json({ 
       success: true,
       hasKey: true,
-      keyLength: apiKey.length,
       modelsCount: modelList.length,
       realtimeModels: realtimeModels.map((model) => model.id)
     });


### PR DESCRIPTION
## Summary
- remove sensitive API key logging and response fields from the /api/test-openai diagnostic route
- rework realtime session bootstrap to connect directly to OpenAI, report auth failures safely, and drop credentials after shutdown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd2f7e67e0832e9542251219f6efd8