### PR TITLE
Enforce documented accessibility and interaction guidelines

### DIFF
--- a/podcast-studio/AGENTS.md
+++ b/podcast-studio/AGENTS.md
@@ -1,0 +1,128 @@
+# Virtual Podcast Studio – Design & UX System
+
+## Scope & Foundations
+- Applies to every UI and UX change inside `podcast-studio/`, including shared primitives, pages, API routes that render HTML, and MDX content.
+- Build on the Tailwind tokens defined in `src/app/globals.css`; extend tokens there instead of hard-coding colours, spacings, or shadows.
+- All guidance assumes SSR + hydration via Next.js App Router. Verify desktop (Chrome/Safari/Firefox) and mobile (iOS Safari + Android Chrome) before shipping.
+
+## Interaction & Accessibility Principles
+- **Keyboard first**: Every flow must be fully operable with a keyboard. Tab order follows visual order and respects WAI-ARIA Authoring Practices.
+- **Focus treatments**: Use `:focus-visible` (not bare `:focus`) to render a clear ring on every focusable element; add `:focus-within` styles for grouped controls.
+- **Focus management**: Trap focus inside modals/drawers, return it to the triggering control, and move focus intentionally when views change.
+- **Hit targets**: Match the visual affordance. If the visible control is `< 24px`, expand the interactive target to at least 24px (44px minimum on mobile).
+- **Comfortable inputs**: On mobile, ensure `<input>` font size ≥ 16px or declare `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />`.
+- **Respect zoom**: Never disable page zoom or pinch gestures.
+- **Hydration-safe fields**: Inputs must keep value and focus through hydration; avoid remounting components on load.
+- **Paste-friendly**: Do not block paste on any `<input>` or `<textarea>`; surface validation errors instead.
+- **Loading feedback**: Buttons entering a pending state keep their original label and show a spinner or progress indicator.
+- **Stateful URLs**: Persist navigational state (filters, tabs, pagination, expanded panels) in the URL using tools like `nuqs` so share/refresh/back/forward work.
+- **Optimistic updates**: Update the UI immediately when success is likely; reconcile on server response. On failure, show an error and roll back or offer Undo.
+- **Ellipsis cues**: Commands that open follow-up steps end with an ellipsis character (`…`).
+- **Confirm destructive work**: Provide confirmations or an Undo window before destructive actions complete.
+- **Touch ergonomics**: Prevent accidental double-tap zoom on controls with `touch-action: manipulation` and set `-webkit-tap-highlight-color` to match the design system.
+- **Forgiving controls**: Make interactions generous with clear affordances, no dead zones, and consistent pointer/keyboard behaviour.
+- **Tooltip pacing**: Delay the first tooltip in a group; subsequent tooltips appear without delay.
+- **Scroll behaviour**: Use `overscroll-behavior: contain` intentionally (e.g., modals/drawers) and persist scroll positions so browser Back/Forward restores prior scroll.
+- **Contextual autofocus**: On desktop screens with a single primary input, autofocus it. Avoid autofocus on mobile to prevent keyboard-induced layout shifts.
+- **Deep links everywhere**: Any state managed via `useState` (filters, tabs, expansion panels, pagination) must support deep-linking.
+- **Clean drag interactions**: Disable text selection and apply `inert` (or aria-hidden/aria-disabled equivalents) to non-drag elements while dragging to avoid selection/hover conflicts.
+- **Links behave like links**: Use `<a>`/`<Link>` for navigation so middle-click, Cmd/Ctrl+Click, and context menus work. Never swap in `<button>` or `<div>` for navigation.
+- **Async announcements**: Expose polite `aria-live` regions for toasts, inline validation, and any optimistic updates that resolve asynchronously.
+- **Locale-aware shortcuts**: Localise keyboard shortcuts for non-QWERTY layouts and render platform-specific symbols in UI hints.
+
+## Motion & Animation
+- Honour `prefers-reduced-motion`; provide reduced or static alternatives.
+- Prefer CSS transitions/animations, then the Web Animations API, and use JS libraries only as a last resort.
+- Animate compositor-friendly properties (`transform`, `opacity`) and avoid expensive layout-affecting properties (`width`, `height`, `top`, `left`).
+- Animate only when it clarifies cause/effect or adds intentional delight. Skip gratuitous motion.
+- Choose easing based on the change (distance, scale, weight) so motion feels natural.
+- Ensure animations are interruptible—user input cancels or skips them.
+- Trigger motion in response to user input; avoid autoplaying sequences.
+- Set the transform origin so movement starts from the element’s “physical” origin.
+
+## Layout & Responsiveness
+- Adjust by a pixel when optical alignment looks better than strict geometry.
+- Every element aligns intentionally to a grid, baseline, edge, or optical center—avoid accidental positioning.
+- Balance contrast between adjacent text and icons (size, stroke, weight, colour) so they feel cohesive.
+- Verify layouts on mobile, laptop, and ultra-wide screens (zoom out to 50% to simulate very wide displays).
+- Respect safe areas (notches/insets) using `env(safe-area-inset-*)` variables where applicable.
+- Avoid unnecessary scrollbars; resolve overflow issues rather than masking them.
+- Let the browser handle sizing with flexbox/grid/intrinsic layout. Avoid JS measurement loops that trigger layout thrash.
+
+## Content & Semantics
+- Provide inline help before relying on tooltips; tooltips are a last resort.
+- Skeleton loaders must mirror final content dimensions to avoid layout shifts.
+- Ensure `<title>` reflects the current page context.
+- Avoid dead ends—every screen presents a next step or recovery path.
+- Design empty, sparse, dense, and error states up front.
+- Use typographic (curly) quotes instead of straight quotes.
+- Prevent widows/orphans and tidy rag/line breaks in rich text.
+- Use tabular numbers (`font-variant-numeric: tabular-nums` or monospace) for comparative data.
+- Pair colour cues with text labels so status is never colour-only.
+- Icons always ship with visible or accessible text labels.
+- Even when visuals omit labels, expose accessible names/labels so assistive tech receives the schema.
+- Use the single-character ellipsis (`…`), not three periods.
+- Apply `scroll-margin-top` to headings that serve as deep-link anchors.
+- Ensure layouts handle very short and very long user-generated content without breaking.
+- Format dates, times, numbers, delimiters, and currencies using the viewer’s locale.
+- Set precise accessible names, hide decorative elements with `aria-hidden`, and verify the accessibility tree regularly.
+- Icon-only buttons require descriptive `aria-label`s.
+- Prefer native semantics (`button`, `a`, `label`, `table`, etc.) before adding ARIA roles.
+- Maintain a hierarchical heading structure and include a "Skip to content" link.
+- Make brand assets discoverable by allowing users to right-click the nav logo to access resources.
+- Use non-breaking spaces (`&nbsp;` or `&NoBreak;`) to keep glued terms together (e.g., `10&nbsp;MB`, `⌘&nbsp;+&nbsp;K`).
+
+## Forms & Inputs
+- Pressing Enter in a text input submits its enclosing form.
+- In `<textarea>`, `⌘/⌃ + Enter` submits; Enter alone inserts a new line.
+- Every form control has an associated `<label>`; clicking the label focuses the control.
+- Keep submit buttons enabled until submission starts; once in-flight, disable them, show a spinner, and attach an idempotency key.
+- Do not block typing—even for numeric-only inputs. Accept input and provide validation feedback instead of suppressing keystrokes.
+- Allow submitting incomplete forms so validation feedback surfaces.
+- Expand checkbox/radio hit areas so the control and label share a generous, unified target.
+- Place error messages adjacent to their fields and move focus to the first invalid control on submit.
+- Configure `autocomplete` and meaningful `name` attributes to support autofill.
+- Enable spellcheck selectively (disable for emails, codes, usernames, etc.).
+- Use accurate `type` and `inputmode` values to trigger helpful keyboards and validation.
+- Ensure placeholders signal emptiness and end with an ellipsis. Provide example formats (e.g., `+1 (123) 456-7890…`, `sk-0123456789…`).
+- Warn users about unsaved changes before navigating away when data loss is possible.
+- Support password managers and 2FA flows; never block pasting one-time codes.
+- Trim trailing whitespace that may be introduced by text replacements/expansions before validation.
+- Style native `<select>` with explicit `background-color` and `color` values to avoid Windows dark-mode contrast bugs.
+
+## Performance & Quality
+- Test against the device/browser matrix: iOS (including Low Power Mode) and macOS Safari at a minimum.
+- Benchmark without extensions or tooling that alter runtime behaviour.
+- Track React re-renders and minimise them; use React DevTools or React Scan as needed.
+- When profiling, throttle CPU and network to expose bottlenecks.
+- Batch DOM reads/writes to minimise layout/paint work.
+- Target <500 ms for POST/PATCH/DELETE operations under normal conditions.
+- Prefer uncontrolled inputs or inexpensive controlled loops to minimise keystroke cost.
+- Virtualise large lists/tables (e.g., with `virtua`) instead of rendering the entire collection.
+- Preload only above-the-fold imagery; lazy-load the rest.
+- Prevent image-driven layout shifts by setting width/height (or aspect ratio) ahead of load.
+- Use `<link rel="preconnect">` for external asset/CDN domains (include `crossorigin` when required).
+- Preload critical fonts and subset them to the used glyph ranges/axes to reduce payload size.
+
+## Visual Design & Theming
+- Layer shadows to emulate ambient plus directional light.
+- Combine semi-transparent borders with shadows for crisp edges.
+- Keep nested border radii concentric—child radius ≤ parent radius.
+- Tint borders, shadows, and text toward the same hue on non-neutral backgrounds for harmony.
+- Choose colour palettes that remain legible for colour-blind users, especially in charts.
+- Use APCA contrast targets for perceptual accuracy and ensure hover/focus/active states increase contrast over rest states.
+- Align the browser UI with the page background via `<meta name="theme-color" content="#000000">` (update the value per theme).
+- Avoid gradient banding; use dithering masks or adjusted stops when necessary.
+
+## Copywriting & Voice (Vercel Preferences)
+- Write in active voice with clear, concise, action-oriented language.
+- Use Title Case (Chicago) for headings and buttons; switch to sentence case on marketing pages when appropriate.
+- Prefer `&` over `and` and keep noun vocabulary consistent.
+- Address the user directly (second person); avoid first-person voice.
+- Use consistent placeholders (`YOUR_API_TOKEN_HERE` for strings, `0123456789` for numbers).
+- Represent counts with numerals, not words.
+- Maintain consistent currency formatting within a context (either 0 or 2 decimal places).
+- Separate numbers and units with a non-breaking space (e.g., `10&nbsp;MB`).
+- Frame messages positively and provide clear recovery steps for errors.
+- Error copy must explain how to resolve the issue (e.g., regenerate credentials) and offer supporting actions.
+- Labels and CTAs should be explicit (e.g., "Save API Key" instead of "Continue").

--- a/podcast-studio/src/app/analytics/page.tsx
+++ b/podcast-studio/src/app/analytics/page.tsx
@@ -213,7 +213,7 @@ export default function AnalyticsPage() {
             }
           />
 
-          <main className="p-6 space-y-6">
+          <main id="main-content" tabIndex={-1} className="p-6 space-y-6">
             <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
               {overviewCards.map((card) => {
                 const Icon = card.icon;

--- a/podcast-studio/src/app/globals.css
+++ b/podcast-studio/src/app/globals.css
@@ -132,11 +132,21 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    -webkit-tap-highlight-color: rgba(147, 51, 234, 0.2);
   }
-  
+
   body {
     @apply bg-background text-foreground antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    scroll-margin-top: 6rem;
   }
   
   /* Enhanced focus styles */

--- a/podcast-studio/src/app/layout.tsx
+++ b/podcast-studio/src/app/layout.tsx
@@ -23,7 +23,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
   viewportFit: "cover",
   themeColor: "#9333ea",
 };

--- a/podcast-studio/src/app/layout.tsx
+++ b/podcast-studio/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { SidebarProvider } from "@/contexts/sidebar-context";
@@ -20,10 +20,12 @@ export const metadata: Metadata = {
   },
 };
 
-export const viewport = {
-  width: 'device-width',
+export const viewport: Viewport = {
+  width: "device-width",
   initialScale: 1,
-  themeColor: '#9333ea',
+  maximumScale: 1,
+  viewportFit: "cover",
+  themeColor: "#9333ea",
 };
 
 export default function RootLayout({
@@ -34,6 +36,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.className} antialiased`} suppressHydrationWarning={true}>
+        <a
+          href="#main-content"
+          className="sr-only focus-visible:not-sr-only focus-visible:fixed focus-visible:left-4 focus-visible:top-4 focus-visible:z-50 focus-visible:rounded-full focus-visible:bg-gray-900 focus-visible:px-4 focus-visible:py-2 focus-visible:text-sm focus-visible:text-white focus-visible:shadow-lg"
+        >
+          Skip to content
+        </a>
         <ApiConfigProvider>
           <SidebarProvider>
             {children}

--- a/podcast-studio/src/app/library/page.tsx
+++ b/podcast-studio/src/app/library/page.tsx
@@ -90,7 +90,7 @@ export default function Library() {
             }
           />
 
-          <main className="p-6 space-y-6">
+          <main id="main-content" tabIndex={-1} className="p-6 space-y-6">
             {/* Hero Section */}
             <div className="rounded-2xl p-6 bg-gradient-to-r from-purple-600 via-fuchsia-500 to-pink-500 text-white shadow-xl">
               <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">

--- a/podcast-studio/src/app/page.tsx
+++ b/podcast-studio/src/app/page.tsx
@@ -248,12 +248,12 @@ export default function Home() {
             title="Research Hub"
             description="Discover and analyze research papers to fuel AI-powered podcast conversations"
             search={{
-              placeholder: "Search papers...",
-              onSearch: (query) => console.log("Search:", query)
+              placeholder: "Search papers…",
+              onSearch: (query) => console.log("Search:", query),
             }}
           />
 
-          <main className="p-6 space-y-8">
+          <main id="main-content" tabIndex={-1} className="p-6 space-y-8">
             {/* Topic Selection */}
             <section className="animate-slide-up">
               <Card>
@@ -276,7 +276,7 @@ export default function Home() {
                           onClick={() => handleTopicToggle(topic.id)}
                           aria-pressed={isSelected}
                           className={cn(
-                            "group flex w-full items-center space-x-4 rounded-xl border-2 p-4 text-left transition-all duration-200 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-200",
+                            "group flex w-full items-center space-x-4 rounded-xl border-2 p-4 text-left transition-all duration-200 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-200 touch-manipulation",
                             isSelected
                               ? `${topic.bgColor} ${topic.borderColor} border-opacity-60 shadow-md`
                               : "bg-white border-gray-200 hover:border-gray-300 hover:shadow-sm"
@@ -333,18 +333,19 @@ export default function Home() {
                       className="flex-1"
                       onClick={handleFetchPapers}
                       disabled={!hasSelectedTopics || loading}
+                      aria-busy={loading}
                     >
-                      {loading ? (
-                        <>
-                          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                          Searching...
-                        </>
-                      ) : (
-                        <>
-                          <Search className="w-4 h-4 mr-2" />
-                          Find Papers
-                        </>
-                      )}
+                      <span className="flex w-full items-center justify-center gap-2">
+                        {loading ? (
+                          <span
+                            className="size-4 animate-spin rounded-full border-2 border-white/60 border-t-transparent"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                        <span className="font-semibold tracking-tight">Find Papers</span>
+                      </span>
                     </Button>
                     <Button
                       variant="outline"
@@ -388,11 +389,11 @@ export default function Home() {
                 </CardHeader>
                 
                 <CardContent className="p-0">
-                  <ScrollArea className="h-96">
+                  <ScrollArea className="h-96" aria-live="polite">
                     {error ? (
-                      <div className="text-center py-12">
+                      <div className="py-12 text-center" role="alert">
                         <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                          <FileText className="w-6 h-6 text-red-600" />
+                          <FileText className="w-6 h-6 text-red-600" aria-hidden="true" />
                         </div>
                         <p className="text-red-600 font-medium mb-2">Error loading papers</p>
                         <p className="text-gray-500 text-sm">{error}</p>

--- a/podcast-studio/src/app/publisher/page.tsx
+++ b/podcast-studio/src/app/publisher/page.tsx
@@ -220,7 +220,7 @@ export default function Publisher() {
             }
           />
 
-          <div className="p-6 space-y-6">
+          <main id="main-content" tabIndex={-1} className="p-6 space-y-6">
             {/* Hero */}
             <Card className="overflow-hidden">
               <CardContent className="p-0">
@@ -499,7 +499,7 @@ export default function Publisher() {
                 </Card>
               </div>
             </div>
-          </div>
+          </main>
         </div>
       </div>
     </div>

--- a/podcast-studio/src/app/studio/page.tsx
+++ b/podcast-studio/src/app/studio/page.tsx
@@ -333,23 +333,6 @@ const StudioPage: React.FC = () => {
 
   const transcriptScrollRef = useRef<HTMLDivElement | null>(null);
 
-  const paperPayload = useMemo(() => {
-    if (!currentPaper) {
-      return null;
-    }
-
-    return {
-      id: currentPaper.id,
-      title: currentPaper.title,
-      authors: currentPaper.authors,
-      primaryAuthor: currentPaper.primaryAuthor,
-      hasAdditionalAuthors: currentPaper.hasAdditionalAuthors,
-      formattedPublishedDate: currentPaper.formattedPublishedDate,
-      abstract: currentPaper.abstract,
-      arxiv_url: currentPaper.arxiv_url ?? undefined,
-    };
-  }, [currentPaper]);
-
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
@@ -873,7 +856,7 @@ const StudioPage: React.FC = () => {
     aiAudioChunksRef.current = [];
     isUploadingRef.current = false;
     hasCapturedAudioRef.current = false;
-  }, [sessionId, stopMicrophonePipeline]);
+  }, [stopMicrophonePipeline]);
 
   const buildConversationPayload = useCallback((): StoredConversation | null => {
     if (!currentPaper || entries.length === 0) {
@@ -1509,7 +1492,7 @@ const StudioPage: React.FC = () => {
             timer={{ duration: sessionDuration, format: formatTime }}
           />
 
-          <main className="p-6 space-y-6">
+          <main id="main-content" tabIndex={-1} className="p-6 space-y-6">
             <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
               <div className="space-y-6">
                 <Card className="shadow-sm border border-slate-200/70 backdrop-blur-sm bg-white/80">

--- a/podcast-studio/src/app/video-studio/page.tsx
+++ b/podcast-studio/src/app/video-studio/page.tsx
@@ -1400,7 +1400,7 @@ export default function VideoStudio() {
               </div>
             }
           />
-          <main className="space-y-6 p-4 sm:p-6">
+          <main id="main-content" tabIndex={-1} className="space-y-6 p-4 sm:p-6">
             <div className="flex flex-col gap-6 xl:flex-row">
               <div className="flex-1 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
                 <div className="border-b border-gray-200 bg-white p-6">
@@ -2091,7 +2091,7 @@ function SimpleInspectorPanel({
                 <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="Search media..."
+                  placeholder="Search media…"
                   value={mediaQuery}
                   onChange={(event) => setMediaQuery(event.target.value)}
                   className="w-full rounded-lg border border-gray-300 py-2 pl-10 pr-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500"

--- a/podcast-studio/src/components/layout/header.tsx
+++ b/podcast-studio/src/components/layout/header.tsx
@@ -58,6 +58,8 @@ export function Header({
     return colors[color as keyof typeof colors] || 'text-gray-500';
   };
 
+  const searchInputId = React.useId();
+
   return (
     <header className="bg-white/80 backdrop-blur-sm border-b border-gray-200/60 px-6 py-5 sticky top-0 z-10">
       <div className="flex items-center justify-between">
@@ -105,11 +107,19 @@ export function Header({
           
           {search && (
             <div className="relative">
-              <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+              <label htmlFor={searchInputId} className="sr-only">
+                {search.placeholder}
+              </label>
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+                aria-hidden="true"
+              />
               <input
-                type="text"
+                id={searchInputId}
+                type="search"
+                inputMode="search"
                 placeholder={search.placeholder}
-                className="pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent bg-white/50 backdrop-blur-sm transition-all"
+                className="w-48 rounded-lg border border-gray-300 bg-white/60 pl-10 pr-4 py-2 text-base text-gray-900 shadow-sm transition focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:outline-none sm:w-64"
                 onChange={(e) => search.onSearch?.(e.target.value)}
               />
             </div>

--- a/podcast-studio/src/components/layout/sidebar.tsx
+++ b/podcast-studio/src/components/layout/sidebar.tsx
@@ -97,7 +97,7 @@ export function Sidebar({
       <div className={`${collapsed ? "p-2" : "p-4"} border-b border-gray-200/60 flex-shrink-0 relative z-10`}>
         <div className={`flex items-center ${collapsed ? "flex-col space-y-2" : "justify-between"}`}>
           {!collapsed && (
-            <Link href="/" className="group cursor-pointer">
+            <Link href="/" className="group cursor-pointer touch-manipulation">
               <div className="flex items-center space-x-3">
                 <div className="w-10 h-10 gradient-primary rounded-xl flex items-center justify-center shadow-glow group-hover:shadow-glow-lg transition-all duration-300">
                   <Headphones className="w-6 h-6 text-white" />
@@ -143,7 +143,7 @@ export function Sidebar({
               key={item.href}
               href={item.href}
               title={collapsed ? item.name : undefined}
-              className={`group flex items-center ${collapsed ? "justify-center px-2 py-3" : "space-x-3 px-3 py-2.5"} rounded-lg transition-all duration-200 relative ${
+              className={`group flex items-center touch-manipulation ${collapsed ? "justify-center px-2 py-3" : "space-x-3 px-3 py-2.5"} rounded-lg transition-all duration-200 relative ${
                 isActive
                   ? "bg-gradient-to-r from-purple-600 to-purple-700 text-white shadow-lg border border-purple-500/30"
                   : "text-gray-700 hover:bg-gray-50 hover:text-purple-700"

--- a/podcast-studio/src/components/layout/user-menu.tsx
+++ b/podcast-studio/src/components/layout/user-menu.tsx
@@ -24,7 +24,8 @@ import { ChevronDown, LogOut, Settings, User } from "lucide-react";
 
 interface UserMenuItem {
   key: UserMenuKey;
-  label: string;
+  menuLabel: string;
+  sheetTitle: string;
   description: string;
   icon: React.ComponentType<{ className?: string }>;
 }
@@ -40,20 +41,22 @@ interface LlmSettingsState {
 const userMenuItems: UserMenuItem[] = [
   {
     key: "profile",
-    label: "Profile",
+    menuLabel: "Profile…",
+    sheetTitle: "Profile",
     description: "Update your public details and contact info.",
     icon: User,
   },
   {
     key: "settings",
-    label: "Workspace settings",
+    menuLabel: "Workspace settings…",
+    sheetTitle: "Workspace settings",
     description: "Configure collaboration preferences and AI providers.",
     icon: Settings,
   },
 ];
 
 const baseFieldClass =
-  "w-full rounded-lg border border-gray-300 bg-white/90 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200";
+  "w-full rounded-lg border border-gray-300 bg-white/90 px-3 py-2 text-base text-gray-900 shadow-sm transition focus-visible:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300";
 
 export function UserMenu() {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -403,7 +406,7 @@ export function UserMenu() {
                         openaiKey: event.target.value,
                       }))
                     }
-                    placeholder="sk-..."
+                    placeholder="sk-0123456789…"
                     className={`${baseFieldClass} flex-1`}
                   />
                   {llmSettings.openaiKey && (
@@ -447,7 +450,7 @@ export function UserMenu() {
                         googleKey: event.target.value,
                       }))
                     }
-                    placeholder="AIza..."
+                    placeholder="AIzaSyExample…"
                     className={`${baseFieldClass} flex-1`}
                   />
                   {llmSettings.googleKey && (
@@ -527,17 +530,17 @@ export function UserMenu() {
             return (
               <DropdownMenuItem
                 key={item.key}
-                className="flex items-center gap-3 rounded-xl px-3 py-2 text-sm text-gray-700 transition-colors focus:bg-purple-50/80 focus:text-gray-900"
+                className="flex touch-manipulation items-center gap-3 rounded-xl px-3 py-2 text-sm text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-200 data-[highlighted]:bg-purple-50/80 data-[highlighted]:text-gray-900"
                 onSelect={(event) => {
                   event.preventDefault();
                   handleItemSelect(item);
                 }}
               >
                 <span className="flex size-9 items-center justify-center rounded-xl bg-purple-50 text-purple-600 shadow-inner">
-                  <Icon className="size-4" />
+                  <Icon className="size-4" aria-hidden="true" />
                 </span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">{item.label}</p>
+                  <p className="text-sm font-medium text-gray-900 truncate">{item.menuLabel}</p>
                   <p className="text-xs text-gray-500 truncate">{item.description}</p>
                 </div>
               </DropdownMenuItem>
@@ -546,14 +549,14 @@ export function UserMenu() {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"
-            className="flex items-center gap-3 px-3 py-2"
+            className="flex touch-manipulation items-center gap-3 px-3 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-200 data-[highlighted]:bg-red-50/80"
             onSelect={(event) => {
               event.preventDefault();
               handleSignOut();
             }}
           >
             <span className="flex size-9 items-center justify-center rounded-xl bg-red-50 text-red-500">
-              <LogOut className="size-4" />
+              <LogOut className="size-4" aria-hidden="true" />
             </span>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium">Sign out</p>
@@ -568,7 +571,7 @@ export function UserMenu() {
           {activeItem ? (
             <>
               <SheetHeader className="border-b border-gray-200 px-6 pt-6 pb-4">
-                <SheetTitle>{activeItem.label}</SheetTitle>
+                <SheetTitle>{activeItem.sheetTitle}</SheetTitle>
                 <SheetDescription>{activeItem.description}</SheetDescription>
               </SheetHeader>
               <div

--- a/podcast-studio/src/components/ui/button.tsx
+++ b/podcast-studio/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2 active:scale-95",
+  "inline-flex touch-manipulation select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2 active:scale-95",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- add a global skip link, mobile viewport tuning, and consistent `main-content` anchors so keyboard users can bypass chrome quickly
- refine the Research Hub controls with labelled search, loading indicators that keep their labels, and polite status messaging in the results pane
- update shared UI primitives and menus to follow input sizing, placeholder, ellipsis, and touch-target guidance while tuning global tap highlight colours

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1aa18de90832e801d0da99409e003