### PR TITLE
Update realtime defaults to latest OpenAI realtime model

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -124,7 +124,7 @@ class RealtimeSession:
         
         try:
             self.openai_ws = await websockets.connect(
-                "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01",
+                "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17",
                 extra_headers=headers
             )
             logger.info("Connected to OpenAI Realtime API")

--- a/podcast-studio/src/contexts/api-config-context.tsx
+++ b/podcast-studio/src/contexts/api-config-context.tsx
@@ -13,7 +13,7 @@ import { ApiKeySecurity } from "@/lib/apiKeySecurity";
 export type LlmProvider = "openai" | "google";
 
 const PROVIDER_DEFAULT_MODELS: Record<LlmProvider, string> = {
-  openai: process.env.NEXT_PUBLIC_OPENAI_REALTIME_MODEL ?? "gpt-4o-realtime-preview-2024-10-01",
+  openai: process.env.NEXT_PUBLIC_OPENAI_REALTIME_MODEL ?? "gpt-4o-realtime-preview-2024-12-17",
   google: process.env.NEXT_PUBLIC_GOOGLE_MODEL ?? "models/gemini-1.5-flash",
 };
 

--- a/podcast-studio/src/lib/ai/providerRegistry.ts
+++ b/podcast-studio/src/lib/ai/providerRegistry.ts
@@ -9,7 +9,7 @@ interface ProviderMetadata {
 
 const providers: Record<SupportedProvider, ProviderMetadata> = {
   openai: {
-    defaultModel: SecureEnv.getWithDefault("OPENAI_MODEL", "gpt-4o-realtime-preview-2024-10-01"),
+    defaultModel: SecureEnv.getWithDefault("OPENAI_MODEL", "gpt-4o-realtime-preview-2024-12-17"),
     supportsRealtime: true,
   },
   google: {


### PR DESCRIPTION
## Summary
- update the backend realtime WebSocket URL to use the current `gpt-4o-realtime-preview-2024-12-17` model
- align the frontend provider defaults with the same model so newly started sessions negotiate with the supported release

## Testing
- npm run lint
- npm run build *(fails: Next.js Turbopack cannot download Inter font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d445918228832ea3719eb1d4dd17b0