### PR TITLE
Fix premature realtime session teardown

### DIFF
--- a/podcast-studio/src/app/studio/page.tsx
+++ b/podcast-studio/src/app/studio/page.tsx
@@ -1215,11 +1215,20 @@ const StudioPage: React.FC = () => {
     setIsAiSpeaking(false);
   }, [buildConversationPayload, phase, stopMicrophonePipeline, teardownRealtime, uploadMicChunks]);
 
+  const stopSessionRef = useRef<(() => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    stopSessionRef.current = stopSession;
+  }, [stopSession]);
+
   useEffect(() => {
     return () => {
-      stopSession().catch(() => {});
+      const latestStop = stopSessionRef.current;
+      if (latestStop) {
+        latestStop().catch(() => {});
+      }
     };
-  }, [stopSession]);
+  }, []);
 
   const handleSendToVideoStudio = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- keep a stable reference to the `stopSession` cleanup handler in the Audio Studio
- ensure the unmount effect only runs the latest cleanup so active sessions stay alive

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f1cef978832e914bfc237f3823fc