### PR TITLE
Stabilize realtime session startup and switch to gpt-realtime-mini

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -124,7 +124,7 @@ class RealtimeSession:
         
         try:
             self.openai_ws = await websockets.connect(
-                "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17",
+                "wss://api.openai.com/v1/realtime?model=gpt-realtime-mini",
                 extra_headers=headers
             )
             logger.info("Connected to OpenAI Realtime API")

--- a/podcast-studio/src/app/api/rt/audio-commit/route.ts
+++ b/podcast-studio/src/app/api/rt/audio-commit/route.ts
@@ -14,16 +14,29 @@ export async function POST(req: Request) {
     console.log(`[DEBUG] Committing audio turn`, { sessionId });
     
     const manager = rtSessionManager.getSession(sessionId);
-    const status = manager.getStatus();
-    
+    let status = manager.getStatus();
+
     // Check if session is ready
     if (status !== 'active') {
-      console.log(`[WARN] Session not ready for audio commit`, { sessionId, status });
-      return NextResponse.json({ 
-        error: 'Session not ready - start session first',
-        status,
-        sessionId 
-      }, { status: 503 });
+      if (status === 'starting') {
+        try {
+          await manager.waitUntilReady();
+          status = manager.getStatus();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Session failed to become ready';
+          console.error(`[ERROR] Session did not reach active state for audio commit`, { sessionId, error: message });
+          return NextResponse.json({ error: message, sessionId }, { status: 503 });
+        }
+      }
+
+      if (status !== 'active') {
+        console.log(`[WARN] Session not ready for audio commit`, { sessionId, status });
+        return NextResponse.json({
+          error: 'Session not ready - start session first',
+          status,
+          sessionId
+        }, { status: 503 });
+      }
     }
     
     await manager.commitTurn();

--- a/podcast-studio/src/app/api/rt/audio/route.ts
+++ b/podcast-studio/src/app/api/rt/audio/route.ts
@@ -13,17 +13,33 @@ export async function GET(req: Request) {
     console.log(`[INFO] Starting audio stream`, { sessionId });
     
     const manager = rtSessionManager.getSession(sessionId);
-    
+
     // Don't start session here - it should already be started
-    const status = manager.getStatus();
+    let status = manager.getStatus();
     console.log(`[INFO] Session status for audio stream`, { sessionId, status });
-    
+
     if (status !== 'active') {
-      console.log(`[WARN] Session not active for audio stream`, { sessionId, status });
-      return new Response(`event: error\ndata: Session not active (status: ${status})\n\n`, {
-        status: 503,
-        headers: { "Content-Type": "text/event-stream" }
-      });
+      if (status === 'starting') {
+        try {
+          await manager.waitUntilReady();
+          status = manager.getStatus();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Session failed to become ready';
+          console.error(`[ERROR] Session did not reach active state for audio stream`, { sessionId, error: message });
+          return new Response(`event: error\ndata: ${message}\n\n`, {
+            status: 503,
+            headers: { "Content-Type": "text/event-stream" }
+          });
+        }
+      }
+
+      if (status !== 'active') {
+        console.log(`[WARN] Session not active for audio stream`, { sessionId, status });
+        return new Response(`event: error\ndata: Session not active (status: ${status})\n\n`, {
+          status: 503,
+          headers: { "Content-Type": "text/event-stream" }
+        });
+      }
     }
     
     let cleanup: (() => void) | undefined;

--- a/podcast-studio/src/app/api/rt/user-transcripts/route.ts
+++ b/podcast-studio/src/app/api/rt/user-transcripts/route.ts
@@ -13,17 +13,33 @@ export async function GET(req: Request) {
     console.log(`[INFO] Starting user transcript stream`, { sessionId });
     
     const manager = rtSessionManager.getSession(sessionId);
-    
+
     // Don't start session here - it should already be started
-    const status = manager.getStatus();
+    let status = manager.getStatus();
     console.log(`[INFO] Session status for user transcript stream`, { sessionId, status });
-    
+
     if (status !== 'active') {
-      console.log(`[WARN] Session not active for user transcript stream`, { sessionId, status });
-      return new Response(`event: error\ndata: Session not active (status: ${status})\n\n`, {
-        status: 503,
-        headers: { "Content-Type": "text/event-stream" }
-      });
+      if (status === 'starting') {
+        try {
+          await manager.waitUntilReady();
+          status = manager.getStatus();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Session failed to become ready';
+          console.error(`[ERROR] Session did not reach active state for user transcript stream`, { sessionId, error: message });
+          return new Response(`event: error\ndata: ${message}\n\n`, {
+            status: 503,
+            headers: { "Content-Type": "text/event-stream" }
+          });
+        }
+      }
+
+      if (status !== 'active') {
+        console.log(`[WARN] Session not active for user transcript stream`, { sessionId, status });
+        return new Response(`event: error\ndata: Session not active (status: ${status})\n\n`, {
+          status: 503,
+          headers: { "Content-Type": "text/event-stream" }
+        });
+      }
     }
     
     let cleanup: (() => void) | undefined;

--- a/podcast-studio/src/app/api/test-openai/route.ts
+++ b/podcast-studio/src/app/api/test-openai/route.ts
@@ -46,7 +46,7 @@ export async function GET() {
     const modelList = Array.isArray(models.data) ? models.data : [];
     console.log('[TEST] Found', modelList.length, 'models');
 
-    // Check if gpt-4o-realtime model is available
+    // Check if gpt-realtime-mini model is available
     const realtimeModels = modelList.filter((model) => typeof model.id === 'string' && model.id.includes('realtime'));
     console.log('[TEST] Realtime models found:', realtimeModels.map((model) => model.id));
     

--- a/podcast-studio/src/contexts/api-config-context.tsx
+++ b/podcast-studio/src/contexts/api-config-context.tsx
@@ -13,7 +13,7 @@ import { ApiKeySecurity } from "@/lib/apiKeySecurity";
 export type LlmProvider = "openai" | "google";
 
 const PROVIDER_DEFAULT_MODELS: Record<LlmProvider, string> = {
-  openai: process.env.NEXT_PUBLIC_OPENAI_REALTIME_MODEL ?? "gpt-4o-realtime-preview-2024-12-17",
+  openai: process.env.NEXT_PUBLIC_OPENAI_REALTIME_MODEL ?? "gpt-realtime-mini",
   google: process.env.NEXT_PUBLIC_GOOGLE_MODEL ?? "models/gemini-1.5-flash",
 };
 

--- a/podcast-studio/src/lib/ai/providerRegistry.ts
+++ b/podcast-studio/src/lib/ai/providerRegistry.ts
@@ -9,7 +9,7 @@ interface ProviderMetadata {
 
 const providers: Record<SupportedProvider, ProviderMetadata> = {
   openai: {
-    defaultModel: SecureEnv.getWithDefault("OPENAI_MODEL", "gpt-4o-realtime-preview-2024-12-17"),
+    defaultModel: SecureEnv.getWithDefault("OPENAI_MODEL", "gpt-realtime-mini"),
     supportsRealtime: true,
   },
   google: {


### PR DESCRIPTION
## Summary
- add a waitUntilReady helper in the realtime session manager and use it across SSE and input routes to avoid premature 503 errors while a session is still starting
- update frontend defaults and backend bridge to target the gpt-realtime-mini model and refresh the OpenAI test route copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e410b8ebe0832e83e01d61f6b6b369

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds waitUntilReady to prevent premature 503s during session startup and switches default realtime model to gpt-realtime-mini across backend and frontend.
> 
> - **Realtime session stability**:
>   - Add `waitUntilReady(timeoutMs)` to `src/lib/realtimeSession.ts` and emit-based readiness handling.
>   - Update routes to await readiness when status is `starting`, avoiding premature 503s:
>     - `api/rt/audio-append`, `api/rt/audio-commit`, `api/rt/text` (JSON APIs)
>     - `api/rt/audio`, `api/rt/transcripts`, `api/rt/user-transcripts` (SSE streams)
> - **Model defaults updated to `gpt-realtime-mini`**:
>   - Backend WebSocket URL in `backend/main.py`.
>   - Frontend defaults: `contexts/api-config-context.tsx`, `lib/ai/providerRegistry.ts`.
>   - OpenAI test route copy in `api/test-openai/route.ts` to reference realtime models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ddafe9d76dcd24c02e1d8b712f571a6b6beac3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->