### PR TITLE
Fix transcript finalization duplication in audio studio

### DIFF
--- a/podcast-studio/src/app/studio/AGENT.md
+++ b/podcast-studio/src/app/studio/AGENT.md
@@ -64,6 +64,9 @@ The component is a client component rendered under `SidebarProvider` and `ApiCon
   AI typing indicator.
 - Auto-scroll is handled by calling `transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth' })`
   whenever transcripts update.
+- Final transcript events replace the temporary streaming text for a segment rather than appending to
+  the accumulated content. This prevents duplicated phrases when the realtime API sends a full
+  transcript after incremental deltas.
 
 ## Conversation Storage & Exports
 - `buildConversationPayload` gathers the current conversation, merges AI/user audio recordings via

--- a/podcast-studio/src/app/studio/page.tsx
+++ b/podcast-studio/src/app/studio/page.tsx
@@ -512,7 +512,8 @@ const StudioPage: React.FC = () => {
     (speaker: Speaker, finalText?: string) => {
       const pendingRef = speaker === "host" ? hostPendingRef : aiPendingRef;
       const activeRef = speaker === "host" ? hostActiveIdRef : aiActiveIdRef;
-      if (!activeRef.current && !pendingRef.current && !finalText) {
+
+      if (!activeRef.current && !pendingRef.current && (finalText == null || finalText === "")) {
         if (speaker === "host") {
           setIsHostSpeaking(false);
         } else {
@@ -525,16 +526,23 @@ const StudioPage: React.FC = () => {
         ensureSegment(speaker);
       }
 
-      if (finalText) {
-        pendingRef.current += finalText;
-      }
-
-      drainPending(speaker, true);
-
       const activeId = activeRef.current;
-      if (activeId) {
-        markEntryFinal(activeId);
+      if (!activeId) {
+        pendingRef.current = "";
+        return;
       }
+
+      if (pendingRef.current) {
+        const chunk = pendingRef.current;
+        pendingRef.current = "";
+        updateEntryText(activeId, (value) => value + chunk);
+      }
+
+      if (typeof finalText === "string") {
+        updateEntryText(activeId, () => finalText);
+      }
+
+      markEntryFinal(activeId);
       activeRef.current = null;
       pendingRef.current = "";
       stopTypingInterval(speaker);
@@ -545,7 +553,7 @@ const StudioPage: React.FC = () => {
         setIsAiSpeaking(false);
       }
     },
-    [drainPending, ensureSegment, markEntryFinal, stopTypingInterval],
+    [ensureSegment, markEntryFinal, stopTypingInterval, updateEntryText],
   );
 
   const resetConversation = useCallback(() => {


### PR DESCRIPTION
## Summary
- ensure final transcript events replace the existing streaming text instead of appending to it in the Audio Studio conversation feed
- document the updated transcript finalization behaviour in the Audio Studio agent guide

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e417474f80832e8021540c0033e4d6